### PR TITLE
Add Email sending functionality to the web app

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,7 @@ See [NOTICES](NOTICES.md) for additional copyright and license notifications.
 * node.js (https://nodejs.org/)
 * docker
 * powershell
+* Papercut for local email testing (https://github.com/ChangemakerStudios/Papercut-SMTP)
 
 ### Setup
 
@@ -52,7 +53,7 @@ These are the available powershell commands to test the application (run them fr
 * `Invoke-Psake TestAPI`: Runs the API related tests. It runs a docker container with a test database and then runs the API
   test suite.
 * `Invoke-Psake TestFrontend`: Runs the frontend tests.
-* `Invoke-Psake Test`: Runs the all the tests.
+* `Invoke-Psake Test`: Runs all the tests.
 
 ## Running API
 ### Setting the secrets locally for Ed-Fi ODS
@@ -110,3 +111,29 @@ If you aren’t satisfied with the build tool and configuration choices, you can
 Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
 
 You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+
+## Email
+
+The application is preconfigured to send emails to localhost.
+The recommended tool to test the email sending functionality is Papercut SMTP.
+
+For production, change the EmailSettings configuration block in `appsettings.json`:
+
+```json
+  "EmailSettings": {
+    "Server": "127.0.0.1",
+    "Port": 25,
+    "Sender": "\"Leadership Portal\" <noreply@test.com>",
+    "Username": "",
+    "Password": ""
+  }
+```
+
+Alternatively, you can create a class that implements the `IEmailSender` interface
+in `src/API/LeadershipProfileAPI/Infrastructure/Email/IEmailSender.cs` and register it
+on the `Startup` class instead of the `SmtpSender` class:
+
+```csharp
+  // Replace SmtpSender with your own implementation
+  services.AddTransient<IEmailSender, SmtpSender>();
+```

--- a/src/API/LeadershipProfileAPI/Infrastructure/Email/EmailSettings.cs
+++ b/src/API/LeadershipProfileAPI/Infrastructure/Email/EmailSettings.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace LeadershipProfileAPI.Infrastructure.Email
+{
+    public class EmailSettings
+    {
+        public string Server { get; set; }
+        public int Port { get; set; }
+        public string Sender { get; set; }
+        public string Username { get; set; }
+        public string Password { get; set; }
+    }
+}

--- a/src/API/LeadershipProfileAPI/Infrastructure/Email/IEmailSender.cs
+++ b/src/API/LeadershipProfileAPI/Infrastructure/Email/IEmailSender.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace LeadershipProfileAPI.Infrastructure.Email
+{
+    public interface IEmailSender
+    {
+        Task SendEmailAsync(string email, string subject, string htmlMessage);
+    }
+}

--- a/src/API/LeadershipProfileAPI/Infrastructure/Email/SmtpSender.cs
+++ b/src/API/LeadershipProfileAPI/Infrastructure/Email/SmtpSender.cs
@@ -1,0 +1,50 @@
+﻿using MailKit.Net.Smtp;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MimeKit;
+using MimeKit.Text;
+using System;
+using System.Threading.Tasks;
+
+namespace LeadershipProfileAPI.Infrastructure.Email
+{
+    public class SmtpSender : IEmailSender
+    {
+        private readonly ILogger<SmtpSender> _logger;
+        private readonly EmailSettings _emailSettings;
+
+
+        public SmtpSender(ILogger<SmtpSender> logger, IOptions<EmailSettings> emailSettings)
+        {
+            _logger = logger;
+            _emailSettings = emailSettings.Value;
+        }
+
+        public async Task SendEmailAsync(string email, string subject, string htmlMessage)
+        {
+            try
+            {
+                var msg = new MimeMessage();
+                msg.From.Add(MailboxAddress.Parse(_emailSettings.Sender));
+                msg.To.Add(MailboxAddress.Parse(email));
+                msg.Subject = subject;
+                msg.Body = new TextPart(TextFormat.Html) { Text = htmlMessage };
+
+                using var smtp = new SmtpClient();
+                await smtp.ConnectAsync(_emailSettings.Server, _emailSettings.Port).ConfigureAwait(false);
+
+                if (!string.IsNullOrWhiteSpace(_emailSettings.Username))
+                {
+                    await smtp.AuthenticateAsync(_emailSettings.Username, _emailSettings.Password).ConfigureAwait(false);
+                }
+
+                await smtp.SendAsync(msg).ConfigureAwait(false);
+                await smtp.DisconnectAsync(true).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Failed to send email to {email}", email);
+            }
+        }
+    }
+}

--- a/src/API/LeadershipProfileAPI/LeadershipProfileAPI.csproj
+++ b/src/API/LeadershipProfileAPI/LeadershipProfileAPI.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MailKit" Version="2.10.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.0" NoWarn="NU1605" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.0" NoWarn="NU1605" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />

--- a/src/API/LeadershipProfileAPI/Startup.cs
+++ b/src/API/LeadershipProfileAPI/Startup.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Net.Http;
 using LeadershipProfileAPI.Infrastructure.Auth;
+using LeadershipProfileAPI.Infrastructure.Email;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
@@ -26,6 +27,8 @@ namespace LeadershipProfileAPI
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.Configure<EmailSettings>(Configuration.GetSection("EmailSettings"));
+
             services.AddCors(); // Make sure you call this previous to AddMvc
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Latest);
 
@@ -36,6 +39,8 @@ namespace LeadershipProfileAPI
                     x => { x.BaseAddress = new Uri(Configuration["ODS-API"]); })
                 .SetHandlerLifetime(TimeSpan.FromMinutes(handlerLifeTimeInMinutes))
                 .AddHttpMessageHandler<AuthenticationDelegatingHandler>();
+
+            services.AddTransient<IEmailSender, SmtpSender>();
 
             services.AddControllers();
 

--- a/src/API/LeadershipProfileAPI/appsettings.json
+++ b/src/API/LeadershipProfileAPI/appsettings.json
@@ -1,5 +1,12 @@
 {
   "AllowedHosts": "*",
   "ODS-API": "https://api.ed-fi.org/",
-  "ODS-API-Client-HandlerLifetimeInMin": "30"
+  "ODS-API-Client-HandlerLifetimeInMin": "30",
+  "EmailSettings": {
+    "Server": "127.0.0.1",
+    "Port": 25,
+    "Sender": "\"Leadership Portal\" <noreply@test.com>",
+    "Username": "",
+    "Password": ""
+  } 
 }


### PR DESCRIPTION
* Adds IEmailSender interface. It can be implemented by the end users to add another email service, like AWS SES or SendGrid.
* Adds SmtpSender class that is configured to send emails to localhost by default. It's configured using the EmailSettings block in appsettings.json.

You can test the email sending class by installing Papercut SMTP and then injecting the IEmailSender service to a controller and adding this line to a controller endpoint:
```csharp
await _mailSender.SendEmailAsync("test@test.com", "Test Message", "<h1>Test message 1</h1>");
```