### PR TITLE
feature/LP-51-Deployment

### DIFF
--- a/src/API/LeadershipProfileAPI/appsettings.Development.json
+++ b/src/API/LeadershipProfileAPI/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "EdFi": "#{LpDatabase}"
+    "EdFi": "server=localhost;database=EdFi_Ods_Populated_Template;Trusted_Connection=True;"
   },
   "Logging": {
     "LogLevel": {

--- a/src/API/LeadershipProfileAPI/appsettings.json
+++ b/src/API/LeadershipProfileAPI/appsettings.json
@@ -3,7 +3,7 @@
   "ODS-API": "https://api.ed-fi.org/",
   "ODS-API-Client-HandlerLifetimeInMin": "30",
   "ConnectionStrings": {
-    "EdFi": "server=localhost;database=EdFi_Ods_Populated_Template;Trusted_Connection=True;"
+    "EdFi": "#{LpDatabase}"
   },
   "EmailSettings": {
     "Server": "127.0.0.1",


### PR DESCRIPTION
Changed connection string transform to use main appsettings not the environment appsettings. Deployment pipeline will need to modify the variable to make the proper connection string change as Octopus Deploy does not yet support .json transforms nor variable replacement.