### PR TITLE
Remove ID sorting from directory list

### DIFF
--- a/src/Web/src/components/DirectoryComponents/TableList.js
+++ b/src/Web/src/components/DirectoryComponents/TableList.js
@@ -16,9 +16,7 @@ const CreateTableList = (props) => {
                     <tr>
                         <th></th>
                         <th>
-                            ID 
-                            <Sorting onSortChange={newStatus => setColumnSort('id', newStatus)}
-                                status={sort.category === 'id' ? sort.value : null} />
+                            ID                
                         </th>
                         <th>
                             Name


### PR DESCRIPTION
For this feature the sorting was removed only the ID column in the main Directory table list (not the Advanced)