### PR TITLE
Add Helpers for Local Dev Docker DB

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,6 +28,7 @@ See [NOTICES](NOTICES.md) for additional copyright and license notifications.
 
 * .net 5 sdk (https://dotnet.microsoft.com/download/dotnet/5.0)
 * SQL Server 2019 (https://www.microsoft.com/en-us/sql-server/sql-server-downloads)
+  * Alternatively use Docker for local development, see more info below
 * node.js (https://nodejs.org/)
 * docker
 * powershell
@@ -66,6 +67,19 @@ These are the available powershell commands to test the application (run them fr
 It can be run directly from the Editor, such as Visual Studio. It must be running along with the React Web application for full functionality.
 
 * If using Visual Studio, set Startup to launch `LeadershipProfileAPI` (using dotnet and Kestrel, not IIS Express)
+
+### Use Docker for Local DB
+
+**Docker database is not recommended for use in a production environment.**
+
+Instead of a typical SQL Server installation, you can use Docker for the local database, similar to the test DB.
+
+* `Invoke-Psake RecreateLocalDatabase`: Destroys and recreates a SQL Server container for local dev
+* `Invoke-Psake RestoreLocalDatabase`: Restores the backup to the local DB without recreating the container
+* `Invoke-Psake UpdateLocalDockerDatabase`: Runs DB migration scripts against the Docker DB
+* `Invoke-Psake SetLocalDockerConnectionString`: Sets up local API configuration to use Docker DB
+* `Invoke-Psake ResetLocalDb`: Combines all of the above to set or reset the Docker DB
+
 ## Available React Scripts
 
 In the Web project directory, you can run the below scripts.

--- a/Readme.md
+++ b/Readme.md
@@ -62,11 +62,18 @@ These are the available powershell commands to test the application (run them fr
 * `Invoke-Psake Test`: Runs all the tests.
 
 ## Running API
-It can be run directly from the Editor, such as Visual Studio. It must be running along with the React Web application for full functionality.git 
-    
+
+It can be run directly from the Editor, such as Visual Studio. It must be running along with the React Web application for full functionality.
+
+* If using Visual Studio, set Startup to launch `LeadershipProfileAPI` (using dotnet and Kestrel, not IIS Express)
 ## Available React Scripts
 
-In the Web project directory, you can run:
+In the Web project directory, you can run the below scripts.
+You may need to manually install the `react-scripts` tool first:
+
+```shell
+npm i react-scripts
+```
 
 ### `npm start`
 

--- a/psake-build-helpers.ps1
+++ b/psake-build-helpers.ps1
@@ -12,6 +12,34 @@ function Exist-Container($name) {
     return $false
 }
 
+function Recreate-Docker-Db($containerName, $dbPort, $dbPass) {
+    if(Exist-Container $containerName) {
+        Write-Host "Removing $containerName"
+        exec { docker rm "$containerName" -f }
+    }
+
+    Write-Host "Creating $containerName"
+    exec { docker run -e 'ACCEPT_EULA=Y' --name "$containerName" -e "SA_PASSWORD=$dbPass" -p "${dbPort}:1433" -d "mcr.microsoft.com/mssql/server:2019-latest" }
+    Write-Host "Pausing for DB to come online"
+    Start-Sleep -s 15
+    Write-Host "DB ready at $containerName"
+}
+
+function Restore-Docker-Db($containerName, $bakDir, $bakFilename, $dbPass, $bakDb, $destDb) {
+    exec { docker exec "$containerName" mkdir -p "/var/opt/mssql/backup"}
+    Write-Host "Copying $bakDir/$bakFilename to container $containerName"
+    exec { docker cp "$bakDir/$bakFilename" "${containerName}:/var/opt/mssql/backup/$bakFilename" }
+
+    $restoreQuery = "RESTORE DATABASE $destDb FROM DISK='/var/opt/mssql/backup/$bakFilename' WITH REPLACE, MOVE '$bakDb`_log' TO '/var/opt/mssql/data/$destDb`_log.ldf', MOVE '$bakDb' TO '/var/opt/mssql/data/$destDb.mdf'"
+    $restoreQuery | Out-File "$bakDir/restore.sql"
+    Write-Host "Copying restore script to container $containerName"
+    exec { docker cp "$bakDir/restore.sql" "${containerName}:/var/opt/mssql/backup/restore.sql" }
+
+    Write-Host "Executing restore on $containerName"
+    exec { docker exec "$containerName" /opt/mssql-tools/bin/sqlcmd -S localhost -U 'sa' -P "$dbPass" -i '/var/opt/mssql/backup/restore.sql' }
+}
+
+
 function Update-Database($roundhouseConnString) {
     exec { rh -f="./src/API/DatabaseMigrations/scripts" -c="$roundhouseConnString" -dc --env $env --noninteractive  } -workingDirectory .
 }

--- a/psakefile.ps1
+++ b/psakefile.ps1
@@ -99,7 +99,7 @@ task RestoreLocalDatabase -description "Restores local db without deleting the c
 }
 
 task RunLocalDatabase -description "Runs the docker container that has the local database" {
-	exec { docker start $testDatabaseContainerName }
+	exec { docker start $localDatabaseContainerName }
 }
 
 task UpdateLocalDockerDatabase -description "Runs the migration scripts on the local docker database" {

--- a/psakefile.ps1
+++ b/psakefile.ps1
@@ -106,6 +106,12 @@ task UpdateLocalDockerDatabase -description "Runs the migration scripts on the l
 	$roundhouseConnString="Server=localhost;Database=$dbName;User Id=sa;Password=$testDatabasePassword;"
 	Update-Database $roundhouseConnString
 }
+
+task SetLocalDockerConnectionString -description "Sets a user secret to override the connection string for the docker db" {
+	$roundhouseConnString="Server=localhost;Database=$dbName;User Id=sa;Password=$testDatabasePassword;"
+	dotnet user-secrets set "ConnectionStrings:EdFi" "$roundhouseConnString" --project $apiProjectFile
+}
+
 task Clean -description "Clean back to a fresh state" -depends RemoveDbTestContainer, RemovePublishFolders {
 	dotnet clean $productSolution
 }

--- a/psakefile.ps1
+++ b/psakefile.ps1
@@ -112,6 +112,9 @@ task SetLocalDockerConnectionString -description "Sets a user secret to override
 	dotnet user-secrets set "ConnectionStrings:EdFi" "$roundhouseConnString" --project $apiProjectFile
 }
 
+task ResetLocalDb -description "Recreates and updates the local docker db" -depends RecreateLocalDatabase, UpdateLocalDockerDatabase, SetLocalDockerConnectionString {
+}
+
 task Clean -description "Clean back to a fresh state" -depends RemoveDbTestContainer, RemovePublishFolders {
 	dotnet clean $productSolution
 }

--- a/src/API/LeadershipProfileAPI/Program.cs
+++ b/src/API/LeadershipProfileAPI/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Serilog;
 using Serilog.Events;
@@ -37,7 +38,14 @@ namespace LeadershipProfileAPI
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
             .UseSerilog()
-                .ConfigureWebHostDefaults(webBuilder =>
+            .ConfigureAppConfiguration((hostContext, builder) =>
+                {
+                    if (hostContext.HostingEnvironment.IsDevelopment())
+                    {
+                        builder.AddUserSecrets<Program>();
+                    }
+                })
+            .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();
                 });


### PR DESCRIPTION
Introduces `psake` build helpers for running the local dev database as a Docker container.

- adds new utility tasks similar to existing ones for Test databases
  - pulls shared functionality to `helpers`
- adds utility tasks to override API configuration for Docker-ized connection string
- fixes Readme for other troubleshooting