### PR TITLE
Add personnel name search

### DIFF
--- a/src/API/DatabaseMigrations/scripts/views/vw_StaffSearch.sql
+++ b/src/API/DatabaseMigrations/scripts/views/vw_StaffSearch.sql
@@ -170,7 +170,7 @@ select s.StaffUSI
      , s.FirstName
      , s.MiddleName
      , s.LastSurname
-     , CONCAT(s.FirstName, ' ', s.MiddleName, ' ', s.LastSurname) as FullName
+     , CONCAT(s.FirstName, ' ', s.LastSurname) as FullName
 
      , staffService.YearsOfService
 

--- a/src/API/DatabaseMigrations/scripts/views/vw_StaffSearch.sql
+++ b/src/API/DatabaseMigrations/scripts/views/vw_StaffSearch.sql
@@ -170,7 +170,7 @@ select s.StaffUSI
      , s.FirstName
      , s.MiddleName
      , s.LastSurname
-     , ''             as FullName
+     , CONCAT(s.FirstName, ' ', s.MiddleName, ' ', s.LastSurname) as FullName
 
      , staffService.YearsOfService
 

--- a/src/API/LeadershipProfileAPI/Data/EdFiDbQueryData.cs
+++ b/src/API/LeadershipProfileAPI/Data/EdFiDbQueryData.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using LeadershipProfileAPI.Data.Models;
@@ -118,7 +119,8 @@ namespace LeadershipProfileAPI.Data
                     ClauseAssignments(body.Assignments), 
                     ClauseCertifications(body.Certifications), 
                     ClauseDegrees(body.Degrees), 
-                    ClauseRatings(body.Ratings)
+                    ClauseRatings(body.Ratings),
+                    ClauseName(body.Name)
                 }
                 .Where(x => !string.IsNullOrWhiteSpace(x))
                 .DefaultIfEmpty(string.Empty)
@@ -202,6 +204,11 @@ namespace LeadershipProfileAPI.Data
             }
 
             return string.Empty;
+        }
+
+        private static string ClauseName(string term)
+        {
+            return !string.IsNullOrEmpty(term) ? $"FullName LIKE '%{term}%'" : string.Empty;
         }
     }
 }

--- a/src/API/LeadershipProfileAPI/Data/Models/ProfileSearchRequest/ProfileSearchRequestBody.cs
+++ b/src/API/LeadershipProfileAPI/Data/Models/ProfileSearchRequest/ProfileSearchRequestBody.cs
@@ -8,5 +8,7 @@
         public ProfileSearchRequestCertifications Certifications { get; set; }
         public ProfileSearchRequestAssignments Assignments { get; set; }
         public ProfileSearchRequestDegrees Degrees { get; set; }
+
+        public string Name { get; set; }
     }
 }

--- a/src/Web/src/components/DirectoryComponents/AdvancedSearchComponent/UseSearchDirectory.js
+++ b/src/Web/src/components/DirectoryComponents/AdvancedSearchComponent/UseSearchDirectory.js
@@ -18,8 +18,8 @@ function UseSearchDirectory() {
     const searchableUrl = useRef(new URL(url));
 
     const [sort, setSort] = useState({
-        category: searchableUrl.current.searchParams.get('sortField') !== null && searchableUrl.current.searchParams.get('sortField') !== 'null' ? searchableUrl.current.searchParams.get('sortField') : 'Id',
-        value: searchableUrl.current.searchParams.get('sortBy') !== null && searchableUrl.current.searchParams.get('sortBy') !== 'null' ? searchableUrl.current.searchParams.get('sortBy') : 'desc',
+        category: searchableUrl.current.searchParams.get('sortField') !== null && searchableUrl.current.searchParams.get('sortField') !== 'null' ? searchableUrl.current.searchParams.get('sortField') : 'id',
+        value: searchableUrl.current.searchParams.get('sortBy') !== null && searchableUrl.current.searchParams.get('sortBy') !== 'null' ? searchableUrl.current.searchParams.get('sortBy') : 'asc',
     });
 
     const [paging, setPaging] = useState({

--- a/src/Web/src/components/DirectoryComponents/DirectoryFilters.js
+++ b/src/Web/src/components/DirectoryComponents/DirectoryFilters.js
@@ -160,7 +160,7 @@ const CreateDirectoryFilters = (props) => {
                 </div>
 
                 <div className="search-sort-container">
-                    <Form className="search-sort-form">
+                    <div className="search-sort-form">
                         <Searching onSearchValueChange = {NameSearch_OnChange}/>
                         <div className="sorting-container">
                             <FormGroup className="mb-2 mr-sm-2 mb-sm-0 sort-by-form-group">
@@ -186,7 +186,7 @@ const CreateDirectoryFilters = (props) => {
                                 </Input>
                             </FormGroup>
                         </div>
-                    </Form>
+                    </div>
                 </div>
             </div>
         );

--- a/src/Web/src/components/DirectoryComponents/DirectoryFilters.js
+++ b/src/Web/src/components/DirectoryComponents/DirectoryFilters.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Form, FormGroup, Label, Input, Row, Col, UncontrolledDropdown, DropdownToggle, DropdownMenu } from 'reactstrap';
 import Searching from './Searching';
 import { FilterIcon } from '../Icons';
@@ -7,7 +7,8 @@ import UseDirectoryFilters from './UseDirectoryFilter';
 const CreateDirectoryFilters = (props) => {
 
     function RenderFilters(data) {
-        const {positions, setPositions} = UseDirectoryFilters();
+        const {positions, setPositions, nameSearch, setNameSearch} = UseDirectoryFilters();
+        const isInitialRender = useRef(true);
 
         function CheckSelectedItem(e, elements, setter) {
             let newElements = [...elements];
@@ -34,11 +35,26 @@ const CreateDirectoryFilters = (props) => {
             let filters = {
                 "Assignments":{
                     "Values": selectedPositions
-                }
+                }, 
+                "Name": nameSearch
             }
 
             props.directoryFilteredSearchCallback(filters);
         }
+        
+        function NameSearch_OnChange(value){
+            setNameSearch(value);
+        }
+
+        useEffect(() => {
+
+            if(isInitialRender.current){
+                isInitialRender.current = false;
+                return;
+            }
+
+            OnChangeSubmit();
+        }, [nameSearch])
 
         const modifiers ={
             setMaxHeight: {
@@ -145,7 +161,7 @@ const CreateDirectoryFilters = (props) => {
 
                 <div className="search-sort-container">
                     <Form className="search-sort-form">
-                        <Searching />
+                        <Searching onSearchValueChange = {NameSearch_OnChange}/>
                         <div className="sorting-container">
                             <FormGroup className="mb-2 mr-sm-2 mb-sm-0 sort-by-form-group">
                                 <Label for="sortBy" className="mr-sm-2">

--- a/src/Web/src/components/DirectoryComponents/Searching.js
+++ b/src/Web/src/components/DirectoryComponents/Searching.js
@@ -11,9 +11,18 @@ const Searching = (props) => {
             onSearchValueChange(value);
     }
 
+    function handleOnKeyUp(e){
+        e.preventDefault();
+        if(e.key === 'Enter' || e.keyCode === '13'){
+            onSearchValueChange(e.target.value);
+        }
+    }
+
     return (
         <FormGroup className="w-50 search-by-name">
-            <Input onChange={e => handleOnChange(e.target.value)} type="text" name="searchByName" placeholder="Search by name" className="w-100" />
+            <Input onChange={e => handleOnChange(e.target.value)}
+            onKeyUp={e => handleOnKeyUp(e)}
+            type="text" name="searchByName" placeholder="Search by name" className="w-100" />
             <SearchIcon stylingId="search-by-name-icon" />
         </FormGroup>
     );

--- a/src/Web/src/components/DirectoryComponents/Searching.js
+++ b/src/Web/src/components/DirectoryComponents/Searching.js
@@ -7,12 +7,13 @@ const Searching = (props) => {
     const { onSearchValueChange } = props;
 
     function handleOnChange(value) {
-        onSearchValueChange(value);
+        if(value.length >= 3 || value.length === 0)
+            onSearchValueChange(value);
     }
 
     return (
         <FormGroup className="w-50 search-by-name">
-            <Input disabled onChange={e => handleOnChange(e.target.value)} type="text" name="searchByName" placeholder="Search by name" className="w-100" />
+            <Input onChange={e => handleOnChange(e.target.value)} type="text" name="searchByName" placeholder="Search by name" className="w-100" />
             <SearchIcon stylingId="search-by-name-icon" />
         </FormGroup>
     );

--- a/src/Web/src/components/DirectoryComponents/UseDirectory.js
+++ b/src/Web/src/components/DirectoryComponents/UseDirectory.js
@@ -19,8 +19,8 @@ function UseDirectory() {
     const searchableUrl = useRef(new URL(url));
 
     const [sort, setSort] = useState({
-        category: searchableUrl.current.searchParams.get('sortField') !== null && searchableUrl.current.searchParams.get('sortField') !== 'null' ? searchableUrl.current.searchParams.get('sortField') : 'Id',
-        value: searchableUrl.current.searchParams.get('sortBy') !== null && searchableUrl.current.searchParams.get('sortBy') !== 'null' ? searchableUrl.current.searchParams.get('sortBy') : 'desc',
+        category: searchableUrl.current.searchParams.get('sortField') !== null && searchableUrl.current.searchParams.get('sortField') !== 'null' ? searchableUrl.current.searchParams.get('sortField') : 'id',
+        value: searchableUrl.current.searchParams.get('sortBy') !== null && searchableUrl.current.searchParams.get('sortBy') !== 'null' ? searchableUrl.current.searchParams.get('sortBy') : 'asc',
     });
 
     const [paging, setPaging] = useState({

--- a/src/Web/src/components/DirectoryComponents/UseDirectoryFilter.js
+++ b/src/Web/src/components/DirectoryComponents/UseDirectoryFilter.js
@@ -4,6 +4,7 @@ import config from '../../config';
 function UseDirectoryFilters () {
     const { API_URL, API_CONFIG } = config();
     const [positions, setPositions] = useState([]);
+    const [nameSearch, setNameSearch] = useState();
 
     async function GetPositions(){
         let unmounted = false;
@@ -34,7 +35,9 @@ function UseDirectoryFilters () {
         GetPositions();
     }, [])
 
-    return {positions, setPositions};
+
+
+    return {positions, nameSearch, setPositions, setNameSearch};
 }
 
 export default UseDirectoryFilters;


### PR DESCRIPTION
- Makes use of `FullName `column in `[vw_StaffSearch]`
- Adds a ClauseCondition to use  `FullName  LIKE '%{term}%'` in `[vw_StaffSearch]`
- Adds on change function for name text input which will trigger the API call if search term is at least 3 characters long (to avoid looking for names with just a single character) and on length zero (to refresh the table as if clearing the filter).