### PR TITLE
Set the page to first when applying filters

### DIFF
--- a/src/API/LeadershipProfileAPI/Data/EdFiDbQueryData.cs
+++ b/src/API/LeadershipProfileAPI/Data/EdFiDbQueryData.cs
@@ -109,8 +109,22 @@ namespace LeadershipProfileAPI.Data
                  offset {(currentPage - 1) * pageSize} rows
                  fetch next {pageSize} rows only
              ";
+            var staff = await _edfiDbContext.StaffSearches.FromSqlRaw(sql, name).ToListAsync();
+            return staff.GroupBy(x => x.StaffUniqueId).Select(x => x.First()).ToList();
+        }
+
+        public async Task<int> GetSearchResultsTotalsAsync(ProfileSearchRequestBody body)
+        { 
+            // Add the 'name' value as sql parameter to avoid SQL injection from raw text
+            var name = new SqlParameter("name", body?.Name ?? string.Empty);
+
+            // Implement the view in SQL, call it here
+            var sql = $@"
+                 select DISTINCT (StaffUSI) from edfi.vw_StaffSearch
+                 {ClauseConditions(body)}
+             ";
             
-            return await _edfiDbContext.StaffSearches.FromSqlRaw(sql, name).ToListAsync();
+            return await _edfiDbContext.StaffSearches.FromSqlRaw(sql, name).CountAsync();
         }
 
         private static string ClauseConditions(ProfileSearchRequestBody body)

--- a/src/API/LeadershipProfileAPI/Features/Search/List.cs
+++ b/src/API/LeadershipProfileAPI/Features/Search/List.cs
@@ -78,9 +78,11 @@ namespace LeadershipProfileAPI.Features.Search
                     .ProjectTo<SearchResult>(_mapper.ConfigurationProvider)
                     .ToList();
 
+                var totalCount = await _dbQueryData.GetSearchResultsTotalsAsync(request.SearchRequestBody);
+
                 return new Response
                 {
-                    TotalCount = await _dbContext.ProfileList.CountAsync(cancellationToken),
+                    TotalCount = totalCount,
                     Page = request.Page,
                     Results = list,
                     PageCount = results.Count

--- a/src/Web/src/components/DirectoryComponents/UseDirectory.js
+++ b/src/Web/src/components/DirectoryComponents/UseDirectory.js
@@ -81,6 +81,7 @@ function UseDirectory() {
                         ...paging,
                         totalSize: response.totalCount,
                         maxPages: Math.ceil(response.totalCount / 10),
+                        page: Math.ceil(response.totalCount / 10) > paging.page ? paging.page : 1
                     });
                 }
             });

--- a/src/Web/src/components/DirectoryComponents/UseDirectory.js
+++ b/src/Web/src/components/DirectoryComponents/UseDirectory.js
@@ -81,7 +81,7 @@ function UseDirectory() {
                         ...paging,
                         totalSize: response.totalCount,
                         maxPages: Math.ceil(response.totalCount / 10),
-                        page: Math.ceil(response.totalCount / 10) > paging.page ? paging.page : 1
+                        page: Math.ceil(response.totalCount / 10) >= paging.page ? paging.page : 1
                     });
                 }
             });


### PR DESCRIPTION
- Set the page to first when applying filters
- Set correct total count of records to determine max pages
- Apply grouping to remove duplicate records caused by left joins of data that a staff member might have more than one (ex. Certificates, Degree, etc.)
- - This solution applies a grouping after getting results from SQL since the query we send uses where clauses over vw_StaffSearch, we could make the grouping in the sql query but we would need to define the columns to which we would group by (possibly the columns in Directory grid)  otherwise we would need to rethink the vw_StaffSearch or use a sproc 