### PR TITLE
Add all remaining filters

### DIFF
--- a/src/API/DatabaseMigrations/scripts/views/vw_ListAllInstitution.sql
+++ b/src/API/DatabaseMigrations/scripts/views/vw_ListAllInstitution.sql
@@ -1,0 +1,13 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE OR ALTER  VIEW [edfi].[vw_ListAllInstitutions] AS
+    SELECT DISTINCT 
+        seoaa.EducationOrganizationId as [Value],
+        eo.NameOfInstitution as [Text]
+    FROM 
+        edfi.StaffEducationOrganizationAssignmentAssociation seoaa
+        INNER JOIN edfi.EducationOrganization eo ON eo.EducationOrganizationId = seoaa.EducationOrganizationId
+    WHERE seoaa.EndDate IS NULL OR seoaa.EndDate >= GETUTCDATE()
+GO

--- a/src/API/DatabaseMigrations/scripts/views/vw_StaffSearch.sql
+++ b/src/API/DatabaseMigrations/scripts/views/vw_StaffSearch.sql
@@ -124,14 +124,14 @@ with staffService as (
                        on de.DescriptorId = rd.PerformanceEvaluationTypeDescriptorId
 ),
 
-staff_school (StaffUSI, School, Position) AS
+staff_school (StaffUSI, School, Position, SchoolId) AS
 (
-    SELECT seoaa.StaffUSI, eo.NameOfInstitution, d.ShortDescription
+    SELECT seoaa.StaffUSI, eo.NameOfInstitution, d.ShortDescription, seoaa.EducationOrganizationId
     FROM edfi.StaffEducationOrganizationAssignmentAssociation seoaa
     INNER JOIN edfi.EducationOrganization eo ON eo.EducationOrganizationId = seoaa.EducationOrganizationId
     INNER JOIN edfi.Descriptor d ON d.DescriptorId = seoaa.StaffClassificationDescriptorId
     WHERE seoaa.EndDate IS NULL OR seoaa.EndDate >= GETUTCDATE()
-    GROUP BY seoaa.StaffUSI, eo.NameOfInstitution, d.ShortDescription
+    GROUP BY seoaa.StaffUSI, eo.NameOfInstitution, d.ShortDescription, seoaa.EducationOrganizationId
 ),
 
 staff_email (StaffUSI, Email) AS (
@@ -191,6 +191,7 @@ select s.StaffUSI
      , perr.Rating    as Rating
 
      , ss.School as Institution
+     , ss.SchoolId as InstitutionId
      , se.Email as Email
      , st.Telephone as Telephone
      , sm.Major as Major

--- a/src/API/LeadershiProfileAPI.Tests/Extensions/ProfileSearchRequestBodyExtensions.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Extensions/ProfileSearchRequestBodyExtensions.cs
@@ -92,5 +92,24 @@ namespace LeadershipProfileAPI.Tests.Extensions
 
             return body;
         }
+
+
+        public static ProfileSearchRequestBody AddInstitutions(this ProfileSearchRequestBody body,
+            ProfileSearchRequestInstitution institutions = null)
+        {
+            if (institutions != null)
+            {
+                body.Institutions = institutions;
+            }
+            else
+            {
+                body.Institutions = new ProfileSearchRequestInstitution
+                {
+                    Values = Enumerable.Range(0, 10).ToList()
+                };
+            }
+
+            return body;
+        }
     }
 }

--- a/src/API/LeadershiProfileAPI.Tests/Features/Search/ListTests.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Features/Search/ListTests.cs
@@ -124,5 +124,19 @@ namespace LeadershipProfileAPI.Tests.Features.Search
             
             response.ShouldNotBeNull();
         }
+
+        [Fact]
+        public async Task ShouldGetResponseWithInstitutionRequest()
+        {
+            var body = new ProfileSearchRequestBody()
+                .AddInstitutions();
+
+            var response = await Testing.Send(new List.Query
+            {
+                SearchRequestBody = body
+            });
+
+            response.ShouldNotBeNull();
+        }
     }
 }

--- a/src/API/LeadershipProfileAPI/Controllers/WebControls/DropDownList/Institutions/InstitutionsController.cs
+++ b/src/API/LeadershipProfileAPI/Controllers/WebControls/DropDownList/Institutions/InstitutionsController.cs
@@ -1,0 +1,33 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using LeadershipProfileAPI.Infrastructure;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace LeadershipProfileAPI.Controllers.WebControls.DropDownList.Institutions
+{
+    [TypeFilter(typeof(ApiExceptionFilter))]
+    [Route("webcontrols/dropdownlist/institutions")]
+    [ApiController]
+    [Authorize]
+    public class InstitutionsController : ControllerBase
+    {
+        private readonly ILogger<InstitutionsController> _logger;
+        private readonly IMediator _mediator;
+
+        public InstitutionsController(ILogger<InstitutionsController> logger, IMediator mediator)
+        {
+            _logger = logger;
+            _mediator = mediator;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult> GetAsync([FromQuery] List.Query query, CancellationToken cancellationToken)
+        {
+            var result = await _mediator.Send(query, cancellationToken);
+            return Ok(result);
+        }
+    }
+}

--- a/src/API/LeadershipProfileAPI/Controllers/WebControls/DropDownList/Institutions/List.cs
+++ b/src/API/LeadershipProfileAPI/Controllers/WebControls/DropDownList/Institutions/List.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using AutoMapper.QueryableExtensions;
+using LeadershipProfileAPI.Data;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace LeadershipProfileAPI.Controllers.WebControls.DropDownList.Institutions
+{
+    public class List
+    {
+        public class Query : IRequest<Response> {}
+
+        public class Response
+        {
+            public ICollection<Institution> Institutions { get; set; }
+        }
+
+        public class Institution
+        {
+            public string Text { get; set; }
+            public int Value { get; set; }
+        }
+
+        public class QueryHandler : IRequestHandler<Query, Response>
+        {
+            private readonly EdFiDbContext _dbContext;
+            private readonly IMapper _mapper;
+
+            public QueryHandler(EdFiDbContext dbContext, IMapper mapper)
+            {
+                _dbContext = dbContext;
+                _mapper = mapper;
+            }
+
+            public async Task<Response> Handle(Query request, CancellationToken cancellationToken)
+            {
+                var list = await _dbContext.ListItemItemInstitutions
+                    .ProjectTo<Institution>(_mapper.ConfigurationProvider)
+                    .ToListAsync(cancellationToken);
+
+                return new Response()
+                {
+                    Institutions = list.OrderBy(x => x.Text).ToList()
+                };
+            }
+        }
+    }
+}

--- a/src/API/LeadershipProfileAPI/Controllers/WebControls/DropDownList/Institutions/MappingProfile.cs
+++ b/src/API/LeadershipProfileAPI/Controllers/WebControls/DropDownList/Institutions/MappingProfile.cs
@@ -1,0 +1,13 @@
+﻿using AutoMapper;
+using LeadershipProfileAPI.Data.Models.ListItem;
+
+namespace LeadershipProfileAPI.Controllers.WebControls.DropDownList.Institutions
+{
+    public class MappingProfile : Profile
+    {
+        public MappingProfile()
+        {
+            CreateMap<ListItemInstitution, List.Institution>();
+        }
+    }
+}

--- a/src/API/LeadershipProfileAPI/Data/EdFiDbContext.cs
+++ b/src/API/LeadershipProfileAPI/Data/EdFiDbContext.cs
@@ -27,6 +27,7 @@ namespace LeadershipProfileAPI.Data
         public DbSet<ListItemCertification> ListItemCertifications { get; set; }
         public DbSet<ListItemDegree> ListItemDegrees { get; set; }
         public DbSet<ListItemSubCategory> ListItemSubCategories { get; set; }
+        public DbSet<ListItemInstitution> ListItemItemInstitutions { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -48,6 +49,10 @@ namespace LeadershipProfileAPI.Data
 
             modelBuilder.Entity<ListItemSubCategory>()
                 .ToView("vw_ListAllSubCategories", "edfi")
+                .HasNoKey();
+
+            modelBuilder.Entity<ListItemInstitution>()
+                .ToView("vw_ListAllInstitutions", "edfi")
                 .HasNoKey();
 
             modelBuilder.Entity<Staff>().ToTable("Staff", schema: "edfi")

--- a/src/API/LeadershipProfileAPI/Data/EdFiDbQueryData.cs
+++ b/src/API/LeadershipProfileAPI/Data/EdFiDbQueryData.cs
@@ -138,7 +138,8 @@ namespace LeadershipProfileAPI.Data
                     ClauseCertifications(body.Certifications), 
                     ClauseDegrees(body.Degrees), 
                     ClauseRatings(body.Ratings),
-                    ClauseName()
+                    ClauseName(),
+                    ClauseInstitution(body.Institutions)
                 }
                 .Where(x => !string.IsNullOrWhiteSpace(x))
                 .DefaultIfEmpty(string.Empty)
@@ -227,6 +228,17 @@ namespace LeadershipProfileAPI.Data
         private static string ClauseName()
         {
             return "(coalesce(TRIM(@name), '') = '' OR FullName LIKE '%' + @name + '%')";
+        }
+
+        private static string ClauseInstitution(ProfileSearchRequestInstitution institutions)
+        {
+            if (institutions != null && institutions.Values.Any())
+            {
+                var whereInstitutions = institutions.Values.Any() ? $"InstitutionId in ({string.Join(",", institutions.Values)})" : string.Empty;
+
+                return $"({whereInstitutions})";
+            }
+            return string.Empty;
         }
     }
 }

--- a/src/API/LeadershipProfileAPI/Data/Models/ListItem/ListItemInstitution.cs
+++ b/src/API/LeadershipProfileAPI/Data/Models/ListItem/ListItemInstitution.cs
@@ -1,0 +1,7 @@
+﻿namespace LeadershipProfileAPI.Data.Models.ListItem
+{
+    public class ListItemInstitution : ListItemBase
+    {
+        
+    }
+}

--- a/src/API/LeadershipProfileAPI/Data/Models/ProfileSearchRequest/ProfileSearchRequestBody.cs
+++ b/src/API/LeadershipProfileAPI/Data/Models/ProfileSearchRequest/ProfileSearchRequestBody.cs
@@ -8,6 +8,7 @@
         public ProfileSearchRequestCertifications Certifications { get; set; }
         public ProfileSearchRequestAssignments Assignments { get; set; }
         public ProfileSearchRequestDegrees Degrees { get; set; }
+        public ProfileSearchRequestInstitution Institutions { get; set; }
 
         public string Name { get; set; }
     }

--- a/src/API/LeadershipProfileAPI/Data/Models/ProfileSearchRequest/ProfileSearchRequestInstitution.cs
+++ b/src/API/LeadershipProfileAPI/Data/Models/ProfileSearchRequest/ProfileSearchRequestInstitution.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace LeadershipProfileAPI.Data.Models.ProfileSearchRequest
+{
+    public class ProfileSearchRequestInstitution
+    {
+        public ICollection<int> Values { get; set; }
+    }
+}

--- a/src/Web/src/App.css
+++ b/src/Web/src/App.css
@@ -125,11 +125,12 @@
 .form-group-filter-with-label {
   display: flex;
   width: 100%;
+  text-align: left !important;
 }
 
 .form-group-filter-with-label label {
   white-space: nowrap;
-  margin: 5px
+  margin: 5px;
 }
 
 .search-sort-form {
@@ -488,4 +489,22 @@ h5{
 
 .profile-card-table tbody{
   font-size: large;
+}
+
+.dropdown-toggle::after{
+  margin-top: 0.55rem;
+  float:right;
+}
+
+.dropdown-menu-filter{
+  cursor: text;
+  margin-bottom: 5px !important;
+}
+.filter-dropdown-clear{  
+  float: right;
+  margin-top: -2.7rem;
+  position: relative;
+}
+.filter-dropdown-clear::after{  
+  content: "X"
 }

--- a/src/Web/src/components/DirectoryComponents/DirectoryFilters.js
+++ b/src/Web/src/components/DirectoryComponents/DirectoryFilters.js
@@ -220,7 +220,7 @@ const CreateDirectoryFilters = (props) => {
                                    </DropdownMenu>
                                </UncontrolledDropdown>
                         </FormGroup>
-                        </Col>      
+                        </Col>
                         <Col>
                             <FormGroup className="mb-2 mr-sm-2 mb-sm-0">
                             <UncontrolledDropdown>

--- a/src/Web/src/components/DirectoryComponents/DirectoryFilters.js
+++ b/src/Web/src/components/DirectoryComponents/DirectoryFilters.js
@@ -7,7 +7,11 @@ import UseDirectoryFilters from './UseDirectoryFilter';
 const CreateDirectoryFilters = (props) => {
 
     function RenderFilters(data) {
-        const {positions, setPositions, nameSearch, setNameSearch} = UseDirectoryFilters();
+        const {positions, setPositions, nameSearch, setNameSearch, 
+            degrees, setDegrees, certifications, setCertifications,
+            yearsOptionRange, setYearsOptionRange, year, setYear,
+            yearRange, setYearRange
+        } = UseDirectoryFilters();
         const isInitialRender = useRef(true);
 
         function CheckSelectedItem(e, elements, setter) {
@@ -24,26 +28,70 @@ const CreateDirectoryFilters = (props) => {
             return elements?.filter(x => x.checked || x.selected).map(x => x.value) ?? [];
         }
 
-        function Position_OnChange(e){
-            CheckSelectedItem(e, positions, setPositions);
-            OnChangeSubmit();
-        }
-
         function OnChangeSubmit(){
             let selectedPositions = GetCheckedOrSelectedValues(positions);
+            let selectedDegrees = GetCheckedOrSelectedValues(degrees);
+            let selectedCertificates = GetCheckedOrSelectedValues(certifications);
 
             let filters = {
                 "Assignments":{
                     "Values": selectedPositions
-                }, 
-                "Name": nameSearch
+                },
+                "Degrees":{
+                    "Values": selectedDegrees
+                },
+                "Certifications":{
+                    "Values": selectedCertificates
+                },
+                "Name": nameSearch,
+                "MinYears": yearRange.min,
+                "MaxYears": yearRange.max
             }
 
             props.directoryFilteredSearchCallback(filters);
         }
         
+        function Position_OnChange(e){
+            CheckSelectedItem(e, positions, setPositions);
+            OnChangeSubmit();
+        }
+
         function NameSearch_OnChange(value){
             setNameSearch(value);
+        }
+
+        function Degree_OnChange(e){
+            CheckSelectedItem(e, degrees, setDegrees);
+            OnChangeSubmit();
+        }
+
+        function Certification_OnChange(e){
+            CheckSelectedItem(e, certifications, setCertifications);
+            OnChangeSubmit();
+        }
+
+        function YearOption_OnChange(value){
+            setYearsOptionRange(value);
+        }
+
+        function Year_OnChange(value){
+            setYear(value);
+
+            if(yearsOptionRange == 0){
+                let atLeast = {
+                    min: value,
+                    max: 0
+                };
+                setYearRange(atLeast);
+            }
+
+            if(yearsOptionRange == 1){
+                let lessThan = {
+                    min: 0,
+                    max: value
+                };
+                setYearRange(lessThan);
+            }
         }
 
         useEffect(() => {
@@ -55,6 +103,14 @@ const CreateDirectoryFilters = (props) => {
 
             OnChangeSubmit();
         }, [nameSearch])
+
+        useEffect(() => {
+            if(isInitialRender.current){
+                isInitialRender.current = false;
+                return;
+            }
+            OnChangeSubmit();
+        }, [yearRange])
 
         const modifiers ={
             setMaxHeight: {
@@ -76,27 +132,12 @@ const CreateDirectoryFilters = (props) => {
 
         return (
             <div>
-                <div className="filters-container">
+                <div className="filters-container col-12">
                     <Form>
                     <Row>
-                        <Col className="filter-select-with-label">
-                        <FormGroup className="mb-2 mt-7 mr-sm-2 mb-sm-0 form-group-filter-with-label">
-                            <Label for="districtSelect" className="mr-sm-2">
-                                <FilterIcon />
-                                <span className="filter-title">Filter by</span>
-                            </Label>
-                            <Input disabled type="select" name="select" id="districtSelect" className="filter-dropdown-sm">
-                                <option>District - All</option>
-                                <option>2</option>
-                                <option>3</option>
-                                <option>4</option>
-                                <option>5</option>
-                            </Input>
-                        </FormGroup>
-                        </Col>
                         <Col>
                         <FormGroup className="mb-2 mr-sm-2 mb-sm-0">
-                            <Input  type="select" name="select" className="filter-dropdown">
+                            <Input disabled type="select" name="select" className="filter-dropdown">
                                 <option>School - All</option>
                                 <option>2</option>
                                 <option>3</option>
@@ -133,26 +174,77 @@ const CreateDirectoryFilters = (props) => {
                                </UncontrolledDropdown>
                         </FormGroup>
                         </Col>
+                        
                         <Col>
-                        <FormGroup className="mb-2 mr-sm-2 mb-sm-0">
-                            <Input disabled type="select" name="select" className="filter-dropdown">
-                                <option>Years of Service - All</option>
-                                <option>2</option>
-                                <option>3</option>
-                                <option>4</option>
-                                <option>5</option>
-                            </Input>
+                            <FormGroup className="mb-2 mr-sm-2 mb-sm-0">
+                            <UncontrolledDropdown>
+                                   <DropdownToggle className="form-group-filter-with-label btn-dropdown" caret>
+                                       Select Degree
+                                   </DropdownToggle>
+                                   <DropdownMenu modifiers={modifiers} right className="btn-dropdown-items">
+                                       {
+                                           Object.keys(degrees).length !== 0 ? (
+                                               degrees.map((positionElement, index) => 
+                                               {
+                                                   return(
+                                                       <div key={index}>
+                                                           <input type="checkbox"
+                                                           style={{"display": "inline"}}
+                                                           name="desc1" 
+                                                           value={positionElement.value}
+                                                           checked={positionElement.checked}
+                                                           onChange={e => {Degree_OnChange(e)}} />
+                                                        <Label style={{"display": "inline"}}>{positionElement.text}</Label></div>)
+                                               })
+                                            ) : ("")
+                                       }
+
+                                   </DropdownMenu>
+                               </UncontrolledDropdown>
                         </FormGroup>
                         </Col>
                         <Col>
                             <FormGroup className="mb-2 mr-sm-2 mb-sm-0">
-                            <Input disabled type="select" name="select" className="filter-dropdown">
-                                <option>Degree - All</option>
-                                <option>2</option>
-                                <option>3</option>
-                                <option>4</option>
-                                <option>5</option>
-                            </Input>
+                                <Input type="select" name="select" className="filter-dropdown" value={yearsOptionRange}
+                                onChange={event => {YearOption_OnChange(event.currentTarget.value);}} >
+                                    <option value="-1">Years</option>
+                                    <option value="0">At Least</option>
+                                    <option value="1">Less Than</option>
+                                </Input>
+                            </FormGroup>
+                        </Col>
+                        <Col>
+                            <FormGroup className="mb-2 mr-sm-2 mb-sm-0">
+                                <Input disabled={yearsOptionRange < 0} type="number" min="0" step="1" value={year} placeholder="Years"
+                                onChange={event => {Year_OnChange(event.target.value);}} />
+                            </FormGroup>
+                        </Col>
+                        <Col>
+                            <FormGroup className="mb-2 mr-sm-2 mb-sm-0">
+                            <UncontrolledDropdown>
+                                   <DropdownToggle className="form-group-filter-with-label btn-dropdown" caret>
+                                       Select Certifications
+                                   </DropdownToggle>
+                                   <DropdownMenu modifiers={modifiers} right className="btn-dropdown-items">
+                                       {
+                                           Object.keys(certifications).length !== 0 ? (
+                                               certifications.map((positionElement, index) => 
+                                               {
+                                                   return(
+                                                       <div key={index}>
+                                                           <input type="checkbox"
+                                                           style={{"display": "inline"}}
+                                                           name="desc1" 
+                                                           value={positionElement.value}
+                                                           checked={positionElement.checked}
+                                                           onChange={e => {Certification_OnChange(e)}} />
+                                                        <Label style={{"display": "inline"}}>{positionElement.text}</Label></div>)
+                                               })
+                                            ) : ("")
+                                       }
+
+                                   </DropdownMenu>
+                               </UncontrolledDropdown>
                         </FormGroup>
                         </Col>
                     </Row>

--- a/src/Web/src/components/DirectoryComponents/DirectoryFilters.js
+++ b/src/Web/src/components/DirectoryComponents/DirectoryFilters.js
@@ -1,8 +1,9 @@
 import React, { useEffect, useRef } from 'react';
-import { Form, FormGroup, Label, Input, Row, Col, UncontrolledDropdown, DropdownToggle, DropdownMenu } from 'reactstrap';
+import { Form, FormGroup, Label, Input, Row, Col, UncontrolledDropdown, DropdownToggle, DropdownMenu, Button } from 'reactstrap';
 import Searching from './Searching';
 import { FilterIcon } from '../Icons';
 import UseDirectoryFilters from './UseDirectoryFilter';
+import DropdownTypeAhead from './DropdownTypeAhead';
 
 const CreateDirectoryFilters = (props) => {
 
@@ -10,7 +11,9 @@ const CreateDirectoryFilters = (props) => {
         const {positions, setPositions, nameSearch, setNameSearch, 
             degrees, setDegrees, certifications, setCertifications,
             yearsOptionRange, setYearsOptionRange, year, setYear,
-            yearRange, setYearRange
+            yearRange, setYearRange, institutions, setInstitutions,
+            filteredInstitutions, setFilteredInstitutions,
+            filterInstitutionValue, setFilterInstitutionValue
         } = UseDirectoryFilters();
         const isInitialRender = useRef(true);
 
@@ -32,7 +35,7 @@ const CreateDirectoryFilters = (props) => {
             let selectedPositions = GetCheckedOrSelectedValues(positions);
             let selectedDegrees = GetCheckedOrSelectedValues(degrees);
             let selectedCertificates = GetCheckedOrSelectedValues(certifications);
-
+            let selectedInstitutions = GetCheckedOrSelectedValues(institutions);
             let filters = {
                 "Assignments":{
                     "Values": selectedPositions
@@ -45,7 +48,10 @@ const CreateDirectoryFilters = (props) => {
                 },
                 "Name": nameSearch,
                 "MinYears": yearRange.min,
-                "MaxYears": yearRange.max
+                "MaxYears": yearRange.max,
+                "Institutions":{
+                    "Values": selectedInstitutions
+                }
             }
 
             props.directoryFilteredSearchCallback(filters);
@@ -94,6 +100,15 @@ const CreateDirectoryFilters = (props) => {
             }
         }
 
+        function Institution_Onchange(e){
+            CheckSelectedItem(e, filteredInstitutions, setFilteredInstitutions);
+            OnChangeSubmit();
+        }
+
+        function institutionFiltering(value){
+            setFilterInstitutionValue(value);
+        }
+
         useEffect(() => {
 
             if(isInitialRender.current){
@@ -111,6 +126,17 @@ const CreateDirectoryFilters = (props) => {
             }
             OnChangeSubmit();
         }, [yearRange])
+
+        useEffect(() =>{
+            if(filterInstitutionValue && filterInstitutionValue.length >= 2){
+                let filterInstitutions = institutions.filter(n => n.text.toLowerCase().includes(filterInstitutionValue.toLowerCase()));
+                setFilteredInstitutions(filterInstitutions);
+                return;
+            }
+            // unfilter and show all institutions from state
+            setFilteredInstitutions(institutions);
+
+        }, [filterInstitutionValue])
 
         const modifiers ={
             setMaxHeight: {
@@ -137,13 +163,34 @@ const CreateDirectoryFilters = (props) => {
                     <Row>
                         <Col>
                         <FormGroup className="mb-2 mr-sm-2 mb-sm-0">
-                            <Input disabled type="select" name="select" className="filter-dropdown">
-                                <option>School - All</option>
-                                <option>2</option>
-                                <option>3</option>
-                                <option>4</option>
-                                <option>5</option>
-                            </Input>
+                        <UncontrolledDropdown>
+                                   <DropdownToggle className="form-group-filter-with-label btn-dropdown" caret>
+                                       Schools
+                                   </DropdownToggle>
+                                   <DropdownMenu modifiers={modifiers} right className="btn-dropdown-items">
+                                       <DropdownTypeAhead 
+                                            value={filterInstitutionValue} 
+                                            changeEvent={(e) => institutionFiltering(e.target.value)} 
+                                            clearEvent={() => institutionFiltering('')} />
+                                       {
+                                           Object.keys(filteredInstitutions).length !== 0 ? (
+                                               filteredInstitutions.map((positionElement, index) => 
+                                               {
+                                                   return(
+                                                       <div key={index}>
+                                                           <input type="checkbox"
+                                                           style={{"display": "inline"}}
+                                                           name="desc1" 
+                                                           value={positionElement.value}
+                                                           checked={positionElement.checked}
+                                                           onChange={e => {Institution_Onchange(e)}} />
+                                                        <Label style={{"display": "inline"}}>{positionElement.text}</Label></div>)
+                                               })
+                                            ) : ("")
+                                       }
+
+                                   </DropdownMenu>
+                               </UncontrolledDropdown>
                         </FormGroup>
                         </Col>
                         <Col>
@@ -173,8 +220,7 @@ const CreateDirectoryFilters = (props) => {
                                    </DropdownMenu>
                                </UncontrolledDropdown>
                         </FormGroup>
-                        </Col>
-                        
+                        </Col>      
                         <Col>
                             <FormGroup className="mb-2 mr-sm-2 mb-sm-0">
                             <UncontrolledDropdown>
@@ -183,6 +229,7 @@ const CreateDirectoryFilters = (props) => {
                                    </DropdownToggle>
                                    <DropdownMenu modifiers={modifiers} right className="btn-dropdown-items">
                                        {
+                                           
                                            Object.keys(degrees).length !== 0 ? (
                                                degrees.map((positionElement, index) => 
                                                {
@@ -198,7 +245,6 @@ const CreateDirectoryFilters = (props) => {
                                                })
                                             ) : ("")
                                        }
-
                                    </DropdownMenu>
                                </UncontrolledDropdown>
                         </FormGroup>

--- a/src/Web/src/components/DirectoryComponents/DropdownTypeAhead.js
+++ b/src/Web/src/components/DirectoryComponents/DropdownTypeAhead.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import {FormGroup, Input, Button} from 'reactstrap';
+
+function DropdownTypeAhead({value, changeEvent, clearEvent}){
+    return(
+        <FormGroup className="filter-dropdown">
+            <Input type="text" className="dropdown-menu-filter"
+                value={value}
+                onChange={changeEvent}
+                autocomplete="off" placeholder="type school" />
+            <Button className="filter-dropdown-clear" onClick={clearEvent}/>
+        </FormGroup>
+    )
+}
+
+export default DropdownTypeAhead;

--- a/src/Web/src/components/DirectoryComponents/UseDirectoryFilter.js
+++ b/src/Web/src/components/DirectoryComponents/UseDirectoryFilter.js
@@ -11,49 +11,37 @@ function UseDirectoryFilters () {
     const [year, setYear] = useState();
     const [yearRange, setYearRange] = useState({min: 0, max: 0})
 
-    async function GetPositions(){
-        FetchFilterData(`webcontrols/dropdownlist/assignments`, (response) => {
-            var newResponse = [];
-            response.assignments.forEach(element => {
+    async function getPositions(){
+        fetchFilterData(`webcontrols/dropdownlist/assignments`, (response) => {
+            responseSetter(response.assignments, setPositions);
+        });
+    }
+
+    async function getDegrees(){
+        fetchFilterData(`webcontrols/dropdownlist/degrees`, (response) => {
+            responseSetter(response.degrees, setDegrees);
+        });
+    }
+
+    async function getCertifications(){
+        fetchFilterData(`webcontrols/dropdownlist/certifications`, (response) => {
+            responseSetter(response.certifications, setCertifications);
+        });
+    }
+
+    function responseSetter(responseObject, setter){
+        var newResponse = [];
+            responseObject.forEach(element => {
                 newResponse.push({
                     "text": element.text,
                     "value": element.value,
                     "checked": false
                 })
             });
-            setPositions(newResponse);
-        });
+        setter(newResponse);
     }
 
-    async function GetDegrees(){
-        FetchFilterData(`webcontrols/dropdownlist/degrees`, (response) => {
-            var newResponse = [];
-            response.degrees.forEach(element => {
-                newResponse.push({
-                    "text": element.text,
-                    "value": element.value,
-                    "checked": false
-                })
-            });
-            setDegrees(newResponse);
-        });
-    }
-
-    async function GetCertifications(){
-        FetchFilterData(`webcontrols/dropdownlist/certifications`, (response) => {
-            var newResponse = [];
-            response.certifications.forEach(element => {
-                newResponse.push({
-                    "text": element.text,
-                    "value": element.value,
-                    "checked": false
-                })
-            });
-            setCertifications(newResponse);
-        });
-    }
-
-    async function FetchFilterData(queryString, callback){
+    async function fetchFilterData(queryString, callback){
         let unmounted = false;
         const apiUrl = new URL(API_URL + queryString);
         fetch(apiUrl, API_CONFIG('GET')
@@ -71,9 +59,9 @@ function UseDirectoryFilters () {
     }
 
     useEffect(() => {
-        GetPositions();
-        GetDegrees();
-        GetCertifications();
+        getPositions();
+        getDegrees();
+        getCertifications();
     }, [])
 
     return {positions, nameSearch, degrees, certifications, yearsOptionRange, year, yearRange,

--- a/src/Web/src/components/DirectoryComponents/UseDirectoryFilter.js
+++ b/src/Web/src/components/DirectoryComponents/UseDirectoryFilter.js
@@ -5,23 +5,62 @@ function UseDirectoryFilters () {
     const { API_URL, API_CONFIG } = config();
     const [positions, setPositions] = useState([]);
     const [nameSearch, setNameSearch] = useState();
+    const [degrees, setDegrees] = useState([]);
+    const [certifications, setCertifications] = useState([]);
+    const [yearsOptionRange, setYearsOptionRange] = useState(-1);
+    const [year, setYear] = useState();
+    const [yearRange, setYearRange] = useState({min: 0, max: 0})
 
     async function GetPositions(){
+        FetchFilterData(`webcontrols/dropdownlist/assignments`, (response) => {
+            var newResponse = [];
+            response.assignments.forEach(element => {
+                newResponse.push({
+                    "text": element.text,
+                    "value": element.value,
+                    "checked": false
+                })
+            });
+            setPositions(newResponse);
+        });
+    }
+
+    async function GetDegrees(){
+        FetchFilterData(`webcontrols/dropdownlist/degrees`, (response) => {
+            var newResponse = [];
+            response.degrees.forEach(element => {
+                newResponse.push({
+                    "text": element.text,
+                    "value": element.value,
+                    "checked": false
+                })
+            });
+            setDegrees(newResponse);
+        });
+    }
+
+    async function GetCertifications(){
+        FetchFilterData(`webcontrols/dropdownlist/certifications`, (response) => {
+            var newResponse = [];
+            response.certifications.forEach(element => {
+                newResponse.push({
+                    "text": element.text,
+                    "value": element.value,
+                    "checked": false
+                })
+            });
+            setCertifications(newResponse);
+        });
+    }
+
+    async function FetchFilterData(queryString, callback){
         let unmounted = false;
-        const apiUrl = new URL(API_URL + `webcontrols/dropdownlist/assignments`);
+        const apiUrl = new URL(API_URL + queryString);
         fetch(apiUrl, API_CONFIG('GET')
         ).then(response => response.json())
         .then((response) => {
-            if (!unmounted && response !== null) {
-                var newResponse = [];
-                response.assignments.forEach(element => {
-                    newResponse.push({
-                        "text": element.text,
-                        "value": element.value,
-                        "checked": false
-                    })
-                });
-                setPositions(newResponse);
+            if (!unmounted && response !== null && typeof(callback) === 'function') {
+                callback(response);
             }
         }).catch(error => {
             console.error(error.message);
@@ -33,11 +72,12 @@ function UseDirectoryFilters () {
 
     useEffect(() => {
         GetPositions();
+        GetDegrees();
+        GetCertifications();
     }, [])
 
-
-
-    return {positions, nameSearch, setPositions, setNameSearch};
+    return {positions, nameSearch, degrees, certifications, yearsOptionRange, year, yearRange,
+         setPositions, setNameSearch, setDegrees, setCertifications, setYearsOptionRange, setYear, setYearRange};
 }
 
 export default UseDirectoryFilters;

--- a/src/Web/src/components/DirectoryComponents/UseDirectoryFilter.js
+++ b/src/Web/src/components/DirectoryComponents/UseDirectoryFilter.js
@@ -10,6 +10,9 @@ function UseDirectoryFilters () {
     const [yearsOptionRange, setYearsOptionRange] = useState(-1);
     const [year, setYear] = useState();
     const [yearRange, setYearRange] = useState({min: 0, max: 0})
+    const [institutions, setInstitutions] = useState([]);
+    const [filteredInstitutions, setFilteredInstitutions] = useState(institutions);
+    const [filterInstitutionValue, setFilterInstitutionValue] = useState();
 
     async function getPositions(){
         fetchFilterData(`webcontrols/dropdownlist/assignments`, (response) => {
@@ -26,6 +29,12 @@ function UseDirectoryFilters () {
     async function getCertifications(){
         fetchFilterData(`webcontrols/dropdownlist/certifications`, (response) => {
             responseSetter(response.certifications, setCertifications);
+        });
+    }
+
+    async function getInstitutions(){
+        fetchFilterData(`webcontrols/dropdownlist/institutions`, (response) => {
+            responseSetter(response.institutions, setInstitutions);
         });
     }
 
@@ -62,10 +71,17 @@ function UseDirectoryFilters () {
         getPositions();
         getDegrees();
         getCertifications();
+        getInstitutions();
     }, [])
 
-    return {positions, nameSearch, degrees, certifications, yearsOptionRange, year, yearRange,
-         setPositions, setNameSearch, setDegrees, setCertifications, setYearsOptionRange, setYear, setYearRange};
+    useEffect(() => {
+        setFilteredInstitutions(institutions);
+    }, [institutions])
+
+    return {positions, nameSearch, degrees, certifications, yearsOptionRange, year, yearRange, 
+        institutions, filteredInstitutions, filterInstitutionValue,
+         setPositions, setNameSearch, setDegrees, setCertifications, setYearsOptionRange, setYear, setYearRange, 
+         setInstitutions, setFilteredInstitutions, setFilterInstitutionValue};
 }
 
 export default UseDirectoryFilters;


### PR DESCRIPTION
_This PR includes all changes from LPV-17 and LPV-31 since most changes introduced were dependent_

Added Degree, Certification and Years filter (LPV-17)
- Simplify method to populate filters
- Add Degree and Certification filter from Advance Search to Directory
- Added Year filter with a dropdown to select (At Least, Less Than) selecting other than the Default option will enable text input
- Added Year text input which will be sent as min or max to API, added a state variable to save selected value in state (will be more useful for a later ticket to preserve user selections).

Added School filter (LPV-31)
-  Added  `DropdownTypeAhead `component to filter school dropdown list 
-  Added `vw_ListAllInstitutions`
- Added `EducationOrganizationId `to `vw_StaffSearch` to apply school filter
-  Added test for new body filter