### PR TITLE
Fix key issue with correct staff id property

### DIFF
--- a/src/Web/src/components/DirectoryComponents/TableList.js
+++ b/src/Web/src/components/DirectoryComponents/TableList.js
@@ -38,7 +38,7 @@ const CreateTableList = (props) => {
                 </thead>
                 <tbody>
                     {data !== [] ? data.map(profile => (
-                        <tr key={profile.id}>
+                        <tr key={profile.staffUniqueId}>
                             <td><span className="dot"></span></td>
                             <td><Link to={`profile/${profile.staffUniqueId}`}>{profile.lastSurname}, {profile.firstName}</Link></td>
                             <td>{profile.institution}</td>


### PR DESCRIPTION
Fix issue with unique key in Directory table rows using the correct property name of ID from `data`