### PR TITLE
Feature/LPV-51 Change Settings from Env. Vars to App Settings

### DIFF
--- a/src/API/LeadershipProfileAPI/Infrastructure/Auth/AuthSettings.cs
+++ b/src/API/LeadershipProfileAPI/Infrastructure/Auth/AuthSettings.cs
@@ -1,0 +1,11 @@
+﻿namespace LeadershipProfileAPI.Infrastructure.Auth
+{
+    public class AuthSettings
+    {
+        public string AuthorityServer { get; set; }
+        public string WebClient { get; set; }
+        public string WebClientRedirectUri { get; set; }
+
+        public string WebClientRedirectUriFull => $"{WebClient}{WebClientRedirectUri}";
+    }
+}

--- a/src/API/LeadershipProfileAPI/Infrastructure/Auth/AuthSettings.cs
+++ b/src/API/LeadershipProfileAPI/Infrastructure/Auth/AuthSettings.cs
@@ -6,6 +6,9 @@
         public string WebClient { get; set; }
         public string WebClientRedirectUri { get; set; }
 
+        public double ForgotPasswordTokenLifeSpanHours { get; set; }
+        public double ValidTokenLifeSpanHours { get; set; }
+
         public string WebClientRedirectUriFull => $"{WebClient}{WebClientRedirectUri}";
     }
 }

--- a/src/API/LeadershipProfileAPI/Program.cs
+++ b/src/API/LeadershipProfileAPI/Program.cs
@@ -40,6 +40,8 @@ namespace LeadershipProfileAPI
             .UseSerilog()
             .ConfigureAppConfiguration((hostContext, builder) =>
                 {
+                    builder.AddEnvironmentVariables();
+
                     if (hostContext.HostingEnvironment.IsDevelopment())
                     {
                         builder.AddUserSecrets<Program>();

--- a/src/API/LeadershipProfileAPI/Startup.cs
+++ b/src/API/LeadershipProfileAPI/Startup.cs
@@ -48,7 +48,7 @@ namespace LeadershipProfileAPI
             services.AddDbContext<EdFiIdentityDbContext>(options => options.UseSqlServer(connectionString));
             services.AddDbContext<EdFiDbContext>(options => options.UseSqlServer(connectionString));
 
-            AddAuth(services);
+            AddAuth(services, Configuration);
 
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Latest);
 
@@ -75,11 +75,12 @@ namespace LeadershipProfileAPI
             });
         }
 
-        private static void AddAuth(IServiceCollection services)
+        private static void AddAuth(IServiceCollection services, IConfiguration configuration)
         {
-            var authorityServer = Environment.GetEnvironmentVariable("AuthorityServer");
-            var webClient = Environment.GetEnvironmentVariable("WebClient");
-            var redirectUri = $"{webClient}{Environment.GetEnvironmentVariable("WebClientRedirectUri")}";
+            var authorityServer = configuration.GetValue<string>("AuthorityServer");
+            var webClient = configuration.GetValue<string>("WebClient");
+            var redirectPath = configuration.GetValue<string>("WebClientRedirectUri");
+            var redirectUri = $"{webClient}{redirectPath}";
 
             services.AddAuthentication(options =>
             {

--- a/src/API/LeadershipProfileAPI/Startup.cs
+++ b/src/API/LeadershipProfileAPI/Startup.cs
@@ -148,11 +148,11 @@ namespace LeadershipProfileAPI
                 .AddDeveloperSigningCredential();
 
             services.Configure<DataProtectionTokenProviderOptions>(opt =>
-                opt.TokenLifespan = TimeSpan.FromHours(Convert.ToDouble(Environment.GetEnvironmentVariable("ForgotPasswordTokenLifeSpanHours")))
+                opt.TokenLifespan = TimeSpan.FromHours(settings.ForgotPasswordTokenLifeSpanHours)
             );
 
             services.Configure<SecurityStampValidatorOptions>(opt =>
-                opt.ValidationInterval = TimeSpan.FromHours(Convert.ToDouble(Environment.GetEnvironmentVariable("ValidTokenLifeSpanHours")))
+                opt.ValidationInterval = TimeSpan.FromHours(settings.ValidTokenLifeSpanHours)
             );
 
             services.ConfigureApplicationCookie(options =>

--- a/src/API/LeadershipProfileAPI/appsettings.json
+++ b/src/API/LeadershipProfileAPI/appsettings.json
@@ -5,6 +5,9 @@
   "ConnectionStrings": {
     "EdFi": "#{LpDatabase}"
   },
+  "AuthorityServer": "https://localhost:5001",
+  "WebClient": "http://localhost",
+  "WebClientRedirectUri": "",
   "EmailSettings": {
     "Server": "127.0.0.1",
     "Port": 25,

--- a/src/API/LeadershipProfileAPI/appsettings.json
+++ b/src/API/LeadershipProfileAPI/appsettings.json
@@ -25,4 +25,4 @@
   "ApplicationConfiguration": {
     "ResetPasswordBaseUrl": "http://localhost:80"
   }
-  }
+}

--- a/src/API/LeadershipProfileAPI/appsettings.json
+++ b/src/API/LeadershipProfileAPI/appsettings.json
@@ -5,9 +5,11 @@
   "ConnectionStrings": {
     "EdFi": "#{LpDatabase}"
   },
-  "AuthorityServer": "https://localhost:5001",
-  "WebClient": "http://localhost",
-  "WebClientRedirectUri": "",
+  "AuthSettings": {
+    "AuthorityServer": "https://localhost:5001",
+    "WebClient": "http://localhost",
+    "WebClientRedirectUri": ""
+  },
   "EmailSettings": {
     "Server": "127.0.0.1",
     "Port": 25,

--- a/src/API/LeadershipProfileAPI/appsettings.json
+++ b/src/API/LeadershipProfileAPI/appsettings.json
@@ -8,7 +8,9 @@
   "AuthSettings": {
     "AuthorityServer": "https://localhost:5001",
     "WebClient": "http://localhost",
-    "WebClientRedirectUri": ""
+    "WebClientRedirectUri": "",
+    "ForgotPasswordTokenLifeSpanHours": 7,
+    "ValidTokenLifeSpanHours": 8
   },
   "EmailSettings": {
     "Server": "127.0.0.1",


### PR DESCRIPTION
Update API startup and settings to load from Environment Variables _optionally_ instead of required, to allow the application to run as an Azure App Service (where environment variables cannot be set explicitly, or are prefixed).

This also leaves these settings open to extension in forks to use other configuration middlewares for Auth settings if desired.