### PR TITLE
Feature/LPV-36 Correct Data Mapping for TPDM 1.0

### DIFF
--- a/src/API/DatabaseMigrations/scripts/views/vw_StaffSearch.sql
+++ b/src/API/DatabaseMigrations/scripts/views/vw_StaffSearch.sql
@@ -3,9 +3,12 @@ with assignments as (
     select seoaa.StaffUSI
          , seoaa.StaffClassificationDescriptorId as [PositionId]
          , ksad.CodeValue  as [Position]
+         , eo.EducationOrganizationId as [InstitutionId]
+         , eo.NameOfInstitution as [Institution]
          , seoaa.BeginDate as StartDate
          , Row_number() over (partition by seoaa.StaffUSI order by BeginDate desc) as "Number"
      from edfi.StaffEducationOrganizationAssignmentAssociation as seoaa
+     join edfi.EducationOrganization eo on eo.EducationOrganizationId = seoaa.EducationOrganizationId
      join edfi.Descriptor as ksad on ksad.DescriptorId = seoaa.StaffClassificationDescriptorId
 )
    , allMeasures as (
@@ -45,16 +48,6 @@ with assignments as (
                        on de.DescriptorId = rd.PerformanceEvaluationTypeDescriptorId
 ),
 
-staff_school (StaffUSI, School, Position, SchoolId) AS
-(
-    SELECT seoaa.StaffUSI, eo.NameOfInstitution, d.ShortDescription, seoaa.EducationOrganizationId
-    FROM edfi.StaffEducationOrganizationAssignmentAssociation seoaa
-    INNER JOIN edfi.EducationOrganization eo ON eo.EducationOrganizationId = seoaa.EducationOrganizationId
-    INNER JOIN edfi.Descriptor d ON d.DescriptorId = seoaa.StaffClassificationDescriptorId
-    WHERE seoaa.EndDate IS NULL OR seoaa.EndDate >= GETUTCDATE()
-    GROUP BY seoaa.StaffUSI, eo.NameOfInstitution, d.ShortDescription, seoaa.EducationOrganizationId
-),
-
 staff_email (StaffUSI, Email) AS (
     SELECT StaffUSI, Email FROM 
     (SELECT StaffUSI, ElectronicMailAddress Email, ROW_NUMBER () OVER (PARTITION BY StaffUSI ORDER BY ElectronicMailTypeDescriptorId) RowNumber
@@ -84,6 +77,8 @@ select s.StaffUSI
      , a.Position     as Assignment
      , a.StartDate
      , a.PositionId   as StaffClassificationDescriptorId
+     , a.Institution
+     , a.InstitutionId
 
      , degreeDescriptor.CodeValue as Degree
      , s.HighestCompletedLevelOfEducationDescriptorId
@@ -92,8 +87,6 @@ select s.StaffUSI
      , mr.Subcategory as RatingSubCategory
      , perr.Rating    as Rating
 
-     , ss.School as Institution
-     , ss.SchoolId as InstitutionId
      , se.Email as Email
      , st.Telephone as Telephone
 from edfi.Staff as s
@@ -110,7 +103,6 @@ from edfi.Staff as s
                and mr.StaffUsi = s.StaffUSI
                and mr.MeasureDate = per.ActualDate
          left join rubric as ru on ru.DescriptorId = perr.PerformanceEvaluationTypeDescriptorId
-         LEFT JOIN staff_school ss ON ss.StaffUSI = s.StaffUSI
          LEFT JOIN staff_email se ON se.StaffUSI = s.StaffUSI
          LEFT JOIN staff_telephone st ON st.StaffUSI = s.StaffUSI         
 GO

--- a/src/API/DatabaseMigrations/scripts/views/vw_StaffSearch.sql
+++ b/src/API/DatabaseMigrations/scripts/views/vw_StaffSearch.sql
@@ -104,5 +104,5 @@ from edfi.Staff as s
                and mr.MeasureDate = per.ActualDate
          left join rubric as ru on ru.DescriptorId = perr.PerformanceEvaluationTypeDescriptorId
          LEFT JOIN staff_email se ON se.StaffUSI = s.StaffUSI
-         LEFT JOIN staff_telephone st ON st.StaffUSI = s.StaffUSI         
+         LEFT JOIN staff_telephone st ON st.StaffUSI = s.StaffUSI
 GO

--- a/src/API/DatabaseMigrations/scripts/views/vw_StaffSearch.sql
+++ b/src/API/DatabaseMigrations/scripts/views/vw_StaffSearch.sql
@@ -75,7 +75,6 @@ select s.StaffUSI
      , s.YearsOfPriorProfessionalExperience as YearsOfService 
 
      , a.Position     as Assignment
-     , a.StartDate
      , a.PositionId   as StaffClassificationDescriptorId
      , a.Institution
      , a.InstitutionId

--- a/src/API/LeadershiProfileAPI.Tests/Extensions/ProfileSearchRequestBodyExtensions.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Extensions/ProfileSearchRequestBodyExtensions.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using LeadershipProfileAPI.Data.Models.ProfileSearchRequest;
 
@@ -6,6 +5,19 @@ namespace LeadershipProfileAPI.Tests.Extensions
 {
     public static class ProfileSearchRequestBodyExtensions
     {
+        public static ProfileSearchRequestBody AddYearsOfPriorExperience(this ProfileSearchRequestBody body, params ProfileSearchYearsOfPriorExperience.Range[] ranges)
+        {
+            body.YearsOfPriorExperienceRanges = ranges.Any()
+                ? new ProfileSearchYearsOfPriorExperience {Values = ranges}
+                : new ProfileSearchYearsOfPriorExperience
+                {
+                    Values = Enumerable.Range(0, 10)
+                        .Select(r => new ProfileSearchYearsOfPriorExperience.Range(r, r+1))
+                        .ToList()
+                };
+
+            return body;
+        }
 
         public static ProfileSearchRequestBody AddRatings(this ProfileSearchRequestBody body, ProfileSearchRequestRatings degrees = null)
         {

--- a/src/API/LeadershiProfileAPI.Tests/Extensions/ProfileSearchRequestBodyExtensions.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Extensions/ProfileSearchRequestBodyExtensions.cs
@@ -44,23 +44,14 @@ namespace LeadershipProfileAPI.Tests.Extensions
             return body;
         }
 
-        public static ProfileSearchRequestBody AddDegrees(this ProfileSearchRequestBody body, ProfileSearchRequestDegrees degrees = null)
+        public static ProfileSearchRequestBody AddDegrees(this ProfileSearchRequestBody body, params int[] degrees)
         {
-            if (degrees != null)
-            {
-                body.Degrees = degrees;
-            }
-            else
-            {
-                body.Degrees = new ProfileSearchRequestDegrees
-                {
-                    Values = Enumerable.Range(0, 10).ToList()
-                };
-            }
+            body.Degrees = degrees.Any()
+                ? new ProfileSearchRequestDegrees{ Values = degrees }
+                : new ProfileSearchRequestDegrees { Values = Enumerable.Range(0, 10).ToList() };
 
             return body;
         }
-
 
         public static ProfileSearchRequestBody AddInstitutions(this ProfileSearchRequestBody body, params int[] institutions)
         {

--- a/src/API/LeadershiProfileAPI.Tests/Extensions/ProfileSearchRequestBodyExtensions.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Extensions/ProfileSearchRequestBodyExtensions.cs
@@ -62,20 +62,11 @@ namespace LeadershipProfileAPI.Tests.Extensions
         }
 
 
-        public static ProfileSearchRequestBody AddInstitutions(this ProfileSearchRequestBody body,
-            ProfileSearchRequestInstitution institutions = null)
+        public static ProfileSearchRequestBody AddInstitutions(this ProfileSearchRequestBody body, params int[] institutions)
         {
-            if (institutions != null)
-            {
-                body.Institutions = institutions;
-            }
-            else
-            {
-                body.Institutions = new ProfileSearchRequestInstitution
-                {
-                    Values = Enumerable.Range(0, 10).ToList()
-                };
-            }
+            body.Institutions = institutions.Any()
+                ? new ProfileSearchRequestInstitution { Values = institutions }
+                : new ProfileSearchRequestInstitution { Values = Enumerable.Range(0, 10).ToList() };
 
             return body;
         }

--- a/src/API/LeadershiProfileAPI.Tests/Extensions/ProfileSearchRequestBodyExtensions.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Extensions/ProfileSearchRequestBodyExtensions.cs
@@ -25,21 +25,11 @@ namespace LeadershipProfileAPI.Tests.Extensions
             return body;
         }
 
-        public static ProfileSearchRequestBody AddAssignments(this ProfileSearchRequestBody body,
-            ProfileSearchRequestAssignments assignments = null)
+        public static ProfileSearchRequestBody AddAssignments(this ProfileSearchRequestBody body, params int[] assignments)
         {
-            if (assignments != null)
-            {
-                body.Assignments = assignments;
-            }
-            else
-            {
-                body.Assignments = new ProfileSearchRequestAssignments
-                {
-                    StartDate = DateTime.UtcNow,
-                    Values = Enumerable.Range(0, 10).ToList()
-                };
-            }
+            body.Assignments = assignments.Any()
+                ? new ProfileSearchRequestAssignments { Values = assignments }
+                : new ProfileSearchRequestAssignments { Values = Enumerable.Range(0, 10).ToList() };
 
             return body;
         }

--- a/src/API/LeadershiProfileAPI.Tests/Features/Search/ListTests.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Features/Search/ListTests.cs
@@ -5,7 +5,6 @@ using Shouldly;
 using System.Threading.Tasks;
 using LeadershipProfileAPI.Data.Models.ProfileSearchRequest;
 using LeadershipProfileAPI.Tests.Extensions;
-using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
@@ -72,6 +71,21 @@ namespace LeadershipProfileAPI.Tests.Features.Search
             exclusiveResultIds.ShouldNotContain(TestDataConstants.StaffUsis.MartaMasterson);
         }
 
+        [Fact]
+        public async Task ShouldNotContainDuplicateResults()
+        {
+            var body = new ProfileSearchRequestBody();
+
+            var results = await SearchAllTestUtility.SearchForAllResults(body);
+
+            results.ShouldNotBeNull();
+
+            var countsById = results
+                .GroupBy(x => x.StaffUniqueId)
+                .Select(x => x.Count());
+
+            countsById.ShouldAllBe(x => x == 1);
+        }
 
         private Task<List.Response> SendSearchQuery(ProfileSearchRequestBody body, int page = 1)
         {

--- a/src/API/LeadershiProfileAPI.Tests/Features/Search/ListTests.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Features/Search/ListTests.cs
@@ -59,15 +59,6 @@ namespace LeadershipProfileAPI.Tests.Features.Search
             response.ShouldNotBeNull();
         }
 
-        [Fact]
-        public async Task ShouldGetResponseWithInstitutionRequest()
-        {
-            var body = new ProfileSearchRequestBody().AddInstitutions();
-
-            var response = await SendSearchQuery(body);
-
-            response.ShouldNotBeNull();
-        }
 
         private Task<List.Response> SendSearchQuery(ProfileSearchRequestBody body, int page = 1)
         {

--- a/src/API/LeadershiProfileAPI.Tests/Features/Search/ListTests.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Features/Search/ListTests.cs
@@ -29,15 +29,6 @@ namespace LeadershipProfileAPI.Tests.Features.Search
         }
 
         [Fact]
-        public async Task ShouldGetResponseWithAssignmentsRequest()
-        {
-            var body = new ProfileSearchRequestBody().AddAssignments();
-            var response = await SendSearchQuery(body);
-
-            response.ShouldNotBeNull();
-        }
-
-        [Fact]
         public async Task ShouldGetResponseWithFullRequest()
         {
             var body = new ProfileSearchRequestBody()

--- a/src/API/LeadershiProfileAPI.Tests/Features/Search/ListTests.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Features/Search/ListTests.cs
@@ -38,15 +38,6 @@ namespace LeadershipProfileAPI.Tests.Features.Search
         }
 
         [Fact]
-        public async Task ShouldGetResponseWithDegreesRequest()
-        {
-            var body = new ProfileSearchRequestBody().AddDegrees();
-            var response = await SendSearchQuery(body);
-
-            response.ShouldNotBeNull();
-        }
-
-        [Fact]
         public async Task ShouldGetResponseWithFullRequest()
         {
             var body = new ProfileSearchRequestBody()

--- a/src/API/LeadershiProfileAPI.Tests/Features/Search/ListTests.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Features/Search/ListTests.cs
@@ -87,6 +87,26 @@ namespace LeadershipProfileAPI.Tests.Features.Search
             countsById.ShouldAllBe(x => x == 1);
         }
 
+        [Fact]
+        public async Task ShouldContainAccurateDirectoryInfo()
+        {
+            var body = new ProfileSearchRequestBody { Name = "Barry Quinoa" };
+
+            var results = await SendSearchQuery(body);
+
+            results.ShouldNotBeNull();
+            var result = results.Results.Single();
+
+            result.StaffUniqueId.ShouldBe(TestDataConstants.StaffUsis.BarryQuinoa);
+            result.FirstName.ShouldBe("Barry");
+            result.LastSurName.ShouldBe("Quinoa");
+            result.FullName.ShouldBe("Barry Quinoa");
+            result.Assignment.ShouldBe("Principal");
+            result.Institution.ShouldBe("Charleston Intermediate School");
+            result.Degree.ShouldBe("Bachelor's");
+            result.YearsOfService.ShouldBe(4);
+        }
+
         private Task<List.Response> SendSearchQuery(ProfileSearchRequestBody body, int page = 1)
         {
             return Testing.Send(new List.Query

--- a/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchAllTestUtility.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchAllTestUtility.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using LeadershipProfileAPI.Data.Models.ProfileSearchRequest;
+using LeadershipProfileAPI.Features.Search;
+using Shouldly;
+using Xunit;
+
+namespace LeadershipProfileAPI.Tests.Features.Search
+{
+    public class SearchAllTestUtility
+    {
+        public static async Task<List<List.SearchResult>> SearchForAllResults(ProfileSearchRequestBody body)
+        {
+            var page = 1;
+            var firstResponse = await SendSearch(body, page);
+            var totalPages = firstResponse.PageCount;
+            var results = firstResponse.Results.ToList();
+
+            while (page < totalPages)
+            {
+                page++;
+                var response = await SendSearch(body, page);
+                results.AddRange(response.Results);
+            }
+
+            return results;
+        }
+
+        [Fact]
+        public async Task ShouldGetAllResults()
+        {
+            var body = new ProfileSearchRequestBody();
+            var totalCount = (await SendSearch(body, 1)).TotalCount;
+
+            var result = await SearchForAllResults(body);
+
+            result.Count.ShouldBe(totalCount);
+        }
+
+        private static Task<List.Response> SendSearch(ProfileSearchRequestBody body, int page)
+        {
+            return Testing.Send(new List.Query
+            {
+                SearchRequestBody = body,
+                SortField = "name",
+                SortBy = "asc",
+                Page = page,
+            });
+        }
+    }
+}

--- a/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchAssignmentFilterTests.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchAssignmentFilterTests.cs
@@ -1,0 +1,64 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using LeadershipProfileAPI.Data.Models.ProfileSearchRequest;
+using LeadershipProfileAPI.Tests.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace LeadershipProfileAPI.Tests.Features.Search
+{
+    public class SearchAssignmentFilterTests
+    {
+        [Fact]
+        public async Task ShouldFilterBySingleAssignment()
+        {
+            var teacher = await GetAssignmentValue("Teacher");
+
+            var body = new ProfileSearchRequestBody().AddAssignments(teacher);
+
+            var results = await SearchAllTestUtility.SearchForAllResults(body);
+
+            results
+                .All(r => r.Assignment == "Teacher")
+                .ShouldBeTrue();
+
+            var resultIds = results.Select(r => r.StaffUniqueId).ToList();
+
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.BartJackson); //Current Teacher
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.MartaMasterson); //Current Teacher
+            resultIds.ShouldNotContain(TestDataConstants.StaffUsis.JacksonBonham); //Never Teacher
+            resultIds.ShouldNotContain(TestDataConstants.StaffUsis.MaryMuffet); //Formerly Teacher
+        }
+
+        [Fact]
+        public async Task ShouldFilterToIncludeMultipleAssignments()
+        {
+            var principal = await GetAssignmentValue("Principal");
+            var assistantPrincipal = await GetAssignmentValue("Assistant Principal");
+
+            var body = new ProfileSearchRequestBody()
+                    .AddAssignments(assistantPrincipal, principal);
+
+            var results = await SearchAllTestUtility.SearchForAllResults(body);
+
+            results
+                .All(r => r.Assignment == "Principal" || r.Assignment == "Assistant Principal")
+                .ShouldBeTrue();
+
+            var resultIds = results.Select(r => r.StaffUniqueId).ToList();
+
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.MaryMuffet); //Principal
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.DonaPage); //Assistant Principal
+            resultIds.ShouldNotContain(TestDataConstants.StaffUsis.BartJackson); //Teacher Only
+            resultIds.ShouldNotContain(TestDataConstants.StaffUsis.MartaMasterson); //Teacher Only
+        }
+
+        private async Task<int> GetAssignmentValue(string assignmentName)
+        {
+            var matchedAssignment = await Testing.DbContextScopeExec(db
+                => db.ListItemAssignments.SingleAsync(d => d.Text == assignmentName));
+            return matchedAssignment.Value;
+        }
+    }
+}

--- a/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchDegreeFilterTests.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchDegreeFilterTests.cs
@@ -1,0 +1,66 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using LeadershipProfileAPI.Data.Models.ProfileSearchRequest;
+using LeadershipProfileAPI.Tests.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace LeadershipProfileAPI.Tests.Features.Search
+{
+    public class SearchDegreeFilterTests
+    {
+        [Fact]
+        public async Task ShouldFilterBySingleDegree()
+        {
+            var bachelors = await GetDegreeValue("Bachelor's");
+
+            var body = new ProfileSearchRequestBody()
+                .AddDegrees(bachelors);
+
+            var results = await SearchAllTestUtility.SearchForAllResults(body);
+
+            results
+                .All(r => r.Degree == "Bachelor's")
+                .ShouldBeTrue();
+
+            var resultIds = results.Select(r => r.StaffUniqueId).ToList();
+
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.BartJackson);
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.JacksonBonham);
+            resultIds.ShouldNotContain(TestDataConstants.StaffUsis.MaryMuffet); //Masters
+            resultIds.ShouldNotContain(TestDataConstants.StaffUsis.DonaPage); //Doctorate
+        }
+
+        [Fact]
+        public async Task ShouldFilterToIncludeMultipleDegrees()
+        {
+            var bachelors = await GetDegreeValue("Bachelor's");
+            var masters = await GetDegreeValue("Master's");
+
+            var body = new ProfileSearchRequestBody()
+                .AddDegrees(bachelors, masters);
+
+            var results = await SearchAllTestUtility.SearchForAllResults(body);
+
+            results
+                .All(r => r.Degree == "Bachelor's" || r.Degree == "Master's")
+                .ShouldBeTrue();
+
+            var resultIds = results.Select(r => r.StaffUniqueId).ToList();
+
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.BartJackson); //Bachelors
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.JacksonBonham); //Bachelors
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.MartyJackson); //Masters
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.MaryMuffet); //Masters
+            resultIds.ShouldNotContain(TestDataConstants.StaffUsis.DonaPage); //Doctorate
+        }
+
+        private async Task<int> GetDegreeValue(string degreeName)
+        {
+            var matchedDegree = await Testing.DbContextScopeExec(db
+                => db.ListItemDegrees.SingleAsync(d => d.Text == degreeName));
+            return matchedDegree.Value;
+        }
+    }
+}

--- a/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchNameFilterTests.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchNameFilterTests.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using LeadershipProfileAPI.Data.Models.ProfileSearchRequest;
+using Shouldly;
+using Xunit;
+
+namespace LeadershipProfileAPI.Tests.Features.Search
+{
+    public class SearchNameFilterTests
+    {
+        [Fact]
+        public async Task ShouldFilterByFirstName()
+        {
+            var body = new ProfileSearchRequestBody { Name = "Bart", };
+
+            var results = await SearchAllTestUtility.SearchForAllResults(body);
+
+            results
+                .All(r => r.FullName.Contains("bart", StringComparison.CurrentCultureIgnoreCase))
+                .ShouldBeTrue();
+
+            var resultIds = results.Select(r => r.StaffUniqueId).ToList();
+
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.BartJackson);
+            resultIds.ShouldNotContain(TestDataConstants.StaffUsis.DonaldJones);
+            resultIds.ShouldNotContain(TestDataConstants.StaffUsis.BarryQuinoa);
+        }
+
+        [Fact]
+        public async Task ShouldFilterByLastName()
+        {
+            var body = new ProfileSearchRequestBody { Name = "Jones", };
+
+            var results = await SearchAllTestUtility.SearchForAllResults(body);
+
+            results
+                .All(r => r.FullName.Contains("Jones", StringComparison.CurrentCultureIgnoreCase))
+                .ShouldBeTrue();
+
+            var resultIds = results.Select(r => r.StaffUniqueId).ToList();
+
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.DonaldJones);
+            resultIds.ShouldNotContain(TestDataConstants.StaffUsis.BarryQuinoa);
+        }
+
+        [Fact]
+        public async Task ShouldFilterByPartialNamesAcrossFields()
+        {
+            var body = new ProfileSearchRequestBody { Name = "jack", };
+
+            var results = await SearchAllTestUtility.SearchForAllResults(body);
+
+            results
+                .All(r => r.FullName.Contains("jack", StringComparison.CurrentCultureIgnoreCase))
+                .ShouldBeTrue();
+
+            var resultIds = results.Select(r => r.StaffUniqueId).ToList();
+
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.BartJackson);
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.MartyJackson);
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.JacksonBonham);
+            resultIds.ShouldNotContain(TestDataConstants.StaffUsis.DonaldJones);
+            resultIds.ShouldNotContain(TestDataConstants.StaffUsis.BarryQuinoa);
+        }
+
+        [Fact]
+        public async Task ShouldFilterByWholeName()
+        {
+            var body = new ProfileSearchRequestBody { Name = "Barry Quinoa", };
+
+            var results = await SearchAllTestUtility.SearchForAllResults(body);
+
+            results
+                .All(r => r.FullName.Contains("Barry Quinoa", StringComparison.CurrentCultureIgnoreCase))
+                .ShouldBeTrue();
+
+            var resultIds = results.Select(r => r.StaffUniqueId).Single();
+
+            resultIds.ShouldBe(TestDataConstants.StaffUsis.BarryQuinoa);
+        }
+    }
+}

--- a/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchSchoolFilterTests.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchSchoolFilterTests.cs
@@ -1,0 +1,72 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using LeadershipProfileAPI.Data.Models.ProfileSearchRequest;
+using LeadershipProfileAPI.Features.Search;
+using LeadershipProfileAPI.Tests.Extensions;
+using Shouldly;
+using Xunit;
+
+namespace LeadershipProfileAPI.Tests.Features.Search
+{
+    public class SearchSchoolFilterTests
+    {
+        [Fact]
+        public async Task ShouldFilterBySingleSchool()
+        {
+            var body = new ProfileSearchRequestBody()
+                .AddInstitutions(TestDataConstants.SchoolIds.LemmElementary);
+
+            var response = await SendSearchQuery(body);
+
+            response.Results
+                .All(r => r.Institution == "Lemm Elementary School")
+                .ShouldBeTrue();
+
+            var resultIds = response.Results.Select(r => r.StaffUniqueId).ToList();
+
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.MaryMuffet);
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.MartyJackson);
+            resultIds.ShouldNotContain(TestDataConstants.StaffUsis.DonaPage); //Not at Lemm
+            resultIds.ShouldNotContain(TestDataConstants.StaffUsis.JacksonBonham); //Not at Lemm
+        }
+
+        [Fact]
+        public async Task ShouldFilterByMultipleSchools()
+        {
+            var body = new ProfileSearchRequestBody()
+                .AddInstitutions(TestDataConstants.SchoolIds.LemmElementary, TestDataConstants.SchoolIds.CarterCollins);
+
+            var response = await SendSearchQuery(body);
+
+            response.Results.All(r => r.Institution == "Lemm Elementary School" || r.Institution == "Carter Collins High School").ShouldBeTrue();
+
+            var resultIds = response.Results.Select(r => r.StaffUniqueId).ToList();
+
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.MaryMuffet);
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.MartyJackson);
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.DonaldJones);
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.JacksonBonham);
+            resultIds.ShouldNotContain(TestDataConstants.StaffUsis.BarryQuinoa); //Previously @ Carter Collins
+        }
+
+        [Fact]
+        public async Task ShouldExcludePreviousAssociations()
+        {
+            var schoolWithNoCurrentAssignments = TestDataConstants.SchoolIds.MountainOak;
+
+            var body = new ProfileSearchRequestBody().AddInstitutions(schoolWithNoCurrentAssignments);
+            var response = await SendSearchQuery(body);
+
+            response.Results.ShouldBeEmpty();
+        }
+
+        private Task<List.Response> SendSearchQuery(ProfileSearchRequestBody body, int page = 1)
+        {
+            return Testing.Send(new List.Query
+            {
+                SearchRequestBody = body,
+                Page = page,
+            });
+        }
+    }
+}

--- a/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchYearsOfPriorExperienceFilterTests.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchYearsOfPriorExperienceFilterTests.cs
@@ -1,0 +1,54 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using LeadershipProfileAPI.Data.Models.ProfileSearchRequest;
+using LeadershipProfileAPI.Tests.Extensions;
+using Shouldly;
+using Xunit;
+
+namespace LeadershipProfileAPI.Tests.Features.Search
+{
+    public class SearchYearsOfPriorExperienceFilterTests
+    {
+        [Fact]
+        public async Task ShouldFilterBySingleRange()
+        {
+            var body = new ProfileSearchRequestBody()
+                .AddYearsOfPriorExperience(new ProfileSearchYearsOfPriorExperience.Range(1, 5));
+
+            var results = await SearchAllTestUtility.SearchForAllResults(body);
+
+            results
+                .All(s => s.YearsOfService >= 1 && s.YearsOfService <= 5)
+                .ShouldBeTrue();
+
+            var resultIds = results.Select(r => r.StaffUniqueId).ToList();
+
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.BartJackson); //1
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.BarryQuinoa); //4
+            resultIds.ShouldNotContain(TestDataConstants.StaffUsis.JacksonBonham); //21
+            resultIds.ShouldNotContain(TestDataConstants.StaffUsis.DonaPage); //35
+        }
+
+        [Fact]
+        public async Task ShouldFilterByMultipleRanges()
+        {
+            var body = new ProfileSearchRequestBody()
+                .AddYearsOfPriorExperience(new ProfileSearchYearsOfPriorExperience.Range(16, 20),
+                    new ProfileSearchYearsOfPriorExperience.Range(25, 30));
+
+            var results = await SearchAllTestUtility.SearchForAllResults(body);
+
+            results
+                .All(s => (s.YearsOfService >= 16 && s.YearsOfService <= 20) || (s.YearsOfService >= 25 && s.YearsOfService <= 30))
+                .ShouldBeTrue();
+
+            var resultIds = results.Select(r => r.StaffUniqueId).ToList();
+
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.MartyJackson); //16
+            resultIds.ShouldContain(TestDataConstants.StaffUsis.DonaldJones); //26.5
+            resultIds.ShouldNotContain(TestDataConstants.StaffUsis.JacksonBonham); //21
+            resultIds.ShouldNotContain(TestDataConstants.StaffUsis.DonaPage); //35
+            resultIds.ShouldNotContain(TestDataConstants.StaffUsis.BarryQuinoa); //4
+        }
+    }
+}

--- a/src/API/LeadershipProfileAPI/Data/EdFiDbContext.cs
+++ b/src/API/LeadershipProfileAPI/Data/EdFiDbContext.cs
@@ -24,7 +24,6 @@ namespace LeadershipProfileAPI.Data
         public DbSet<ListItemDegree> ListItemDegrees { get; set; }
         public DbSet<ListItemSubCategory> ListItemSubCategories { get; set; }
         public DbSet<ListItemInstitution> ListItemItemInstitutions { get; set; }
-        public DbSet<StaffSearchGroup> StaffSearchGroups { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -76,8 +75,6 @@ namespace LeadershipProfileAPI.Data
             modelBuilder.Entity<StaffSearch>()
                 .ToView("vw_StaffSearch", "edfi")
                 .HasNoKey();
-
-            modelBuilder.Entity<StaffSearchGroup>().HasNoKey();
         }
     }
 

--- a/src/API/LeadershipProfileAPI/Data/EdFiDbQueryData.cs
+++ b/src/API/LeadershipProfileAPI/Data/EdFiDbQueryData.cs
@@ -89,7 +89,7 @@ namespace LeadershipProfileAPI.Data
 
             // Implement the view in SQL, call it here
             var sql = $@"
-                 select DISTINCT (StaffUSI) from edfi.vw_StaffSearch
+                 select StaffUSI from edfi.vw_StaffSearch
                  {ClauseConditions(body)}
              ";
 

--- a/src/API/LeadershipProfileAPI/Data/EdFiDbQueryData.cs
+++ b/src/API/LeadershipProfileAPI/Data/EdFiDbQueryData.cs
@@ -115,17 +115,9 @@ namespace LeadershipProfileAPI.Data
 
         private static string ClauseAssignments(ProfileSearchRequestAssignments assignments)
         {
-            if (assignments != null && (assignments.StartDate.HasValue || assignments.Values.Any()))
-            {
-                // Provide the condition being searched for matching your schema. Examples: "(a.StartDate = '1982-07-14')" or "(a.StartDate = '1982-07-14' and a.PositionId IN (5432, 234, 5331, 34))"
-                var whereStart = assignments.StartDate.HasValue ? $"datediff(day, StartDate, '{assignments.StartDate.Value.ToShortDateString()}') = 0" : string.Empty;
-                var andStartAndAssignment = assignments.StartDate.HasValue && assignments.Values.Any() ? " and " : string.Empty;
-                var whereAssignment = assignments.Values.Any() ? $"StaffClassificationDescriptorId in ({string.Join(",", assignments.Values)})" : string.Empty;
-
-                return $"({whereStart}{andStartAndAssignment}{whereAssignment})";
-            }
-
-            return string.Empty;
+            return assignments != null && (assignments.Values.Any())
+                ? $"(StaffClassificationDescriptorId in ({string.Join(",", assignments.Values)}))"
+                : string.Empty;
         }
 
         private static string ClauseDegrees(ProfileSearchRequestDegrees degrees)

--- a/src/API/LeadershipProfileAPI/Data/EdFiDbQueryData.cs
+++ b/src/API/LeadershipProfileAPI/Data/EdFiDbQueryData.cs
@@ -33,32 +33,21 @@ namespace LeadershipProfileAPI.Data
         /// <param name="currentPage">When paginating the data, which page of data should be returned</param>
         /// <param name="pageSize">The number of records returned in the result</param>
         /// <returns></returns>
-        public async Task<IList<StaffSearchGroup>> GetSearchResultsAsync(ProfileSearchRequestBody body,
+        public Task<List<StaffSearch>> GetSearchResultsAsync(ProfileSearchRequestBody body,
             string sortBy = "asc", string sortField = "name", int currentPage = 1, int pageSize = 10)
         {
-            // List of columns in the select/group query
-            string[] columns = {
-                    "staff.StaffUniqueId"
-                    , "staff.FirstName"
-                    , "staff.LastSurname"
-                    , "staff.Institution"
-                    , "staff.Assignment"
-                    , "staff.YearsOfService"
-                    , "staff.Degree"
-            };
-
             // Map the UI sorted field name to a table field name
             var fieldMapping = new Dictionary<string, string>
             {
-                {"id", "staff.StaffUniqueId"},
-                {"name", "staff.LastSurName"},
-                {"yearsOfService", "staff.YearsOfService"},
-                {"position", "staff.Assignment"},
-                {"highestDegree", "staff.Degree"},
-                {"ratingCategory", "staff.RatingCategory"},
-                {"ratingSubCategory", "staff.RatingSubCategory"},
-                {"rating", "staff.rating"},
-                {"school", "staff.Institution"},
+                {"id", "StaffUniqueId"},
+                {"name", "LastSurName"},
+                {"yearsOfService", "YearsOfService"},
+                {"position", "Assignment"},
+                {"highestDegree", "Degree"},
+                {"ratingCategory", "RatingCategory"},
+                {"ratingSubCategory", "RatingSubCategory"},
+                {"rating", "rating"},
+                {"school", "Institution"},
             };
 
             // Add the 'name' value as sql parameter to avoid SQL injection from raw text
@@ -67,19 +56,25 @@ namespace LeadershipProfileAPI.Data
             // Implement the view in SQL, call it here
             var sql = $@"
                 select 
-                    {string.Join(", ", columns)}
-                FROM(
-                    select * from edfi.vw_StaffSearch
-                    {ClauseConditions(body)}
-                ) staff
-                group by
-                    {string.Join(", ", columns)}
+                     StaffUSI
+                    ,StaffUniqueId
+                    ,FirstName
+                    ,MiddleName
+                    ,LastSurname
+                    ,FullName
+                    ,YearsOfService
+                    ,Assignment
+                    ,Institution
+                    ,Degree
+                    ,Email
+                    ,Telephone
+                from edfi.vw_StaffSearch
+                {ClauseConditions(body)}
                 order by case when {fieldMapping[sortField]} is null then 1 else 0 end, {fieldMapping[sortField]} {sortBy}
                 offset {(currentPage - 1) * pageSize} rows
                 fetch next {pageSize} rows only
              ";
-            var staff = await _edfiDbContext.StaffSearchGroups.FromSqlRaw(sql, name).ToListAsync();
-            return staff;
+            return _edfiDbContext.StaffSearches.FromSqlRaw(sql, name).ToListAsync();
         }
 
         public async Task<int> GetSearchResultsTotalsAsync(ProfileSearchRequestBody body)

--- a/src/API/LeadershipProfileAPI/Data/Models/ProfileSearchRequest/ProfileSearchRequestAssignments.cs
+++ b/src/API/LeadershipProfileAPI/Data/Models/ProfileSearchRequest/ProfileSearchRequestAssignments.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace LeadershipProfileAPI.Data.Models.ProfileSearchRequest
 {
     public class ProfileSearchRequestAssignments
     {
-        public DateTime? StartDate { get; set; }
         public ICollection<int> Values { get; set; }
     }
 }

--- a/src/API/LeadershipProfileAPI/Data/Models/ProfileSearchRequest/ProfileSearchYearsOfPriorExperience.cs
+++ b/src/API/LeadershipProfileAPI/Data/Models/ProfileSearchRequest/ProfileSearchYearsOfPriorExperience.cs
@@ -8,6 +8,14 @@ namespace LeadershipProfileAPI.Data.Models.ProfileSearchRequest
 
         public class Range
         {
+            public Range() { }
+
+            public Range(int min, int max)
+            {
+                Min = min;
+                Max = max;
+            }
+
             public int Min { get; set; }
             public int Max { get; set; }
         }

--- a/src/API/LeadershipProfileAPI/Data/Models/StaffSearch.cs
+++ b/src/API/LeadershipProfileAPI/Data/Models/StaffSearch.cs
@@ -11,9 +11,6 @@
         public decimal? YearsOfService { get; set; }
         public string Assignment { get; set; }
         public string Degree { get; set; }
-        public string RatingCategory { get; set; }
-        public string RatingSubCategory { get; set; }
-        public decimal? Rating { get; set; }
         public string Institution { get; set; }
         public string Email { get; set; }
         public string Telephone { get; set; }

--- a/src/API/LeadershipProfileAPI/Data/Models/StaffSearch.cs
+++ b/src/API/LeadershipProfileAPI/Data/Models/StaffSearch.cs
@@ -15,15 +15,4 @@
         public string Email { get; set; }
         public string Telephone { get; set; }
     }
-
-    public class StaffSearchGroup
-    {
-        public string StaffUniqueId { get; set; }
-        public string FirstName { get; set; }
-        public string LastSurname { get; set; }
-        public decimal? YearsOfService { get; set; }
-        public string Assignment { get; set; }
-        public string Degree { get; set; }
-        public string Institution { get; set; }
-    }
 }

--- a/src/API/LeadershipProfileAPI/Features/Search/List.cs
+++ b/src/API/LeadershipProfileAPI/Features/Search/List.cs
@@ -60,24 +60,27 @@ namespace LeadershipProfileAPI.Features.Search
 
             public async Task<Response> Handle(Query request, CancellationToken cancellationToken)
             {
+                const int pageSize = 10;
                 var results = await _dbQueryData.GetSearchResultsAsync(
                     request.SearchRequestBody,
                     request.SortBy ?? "asc",
                     request.SortField ?? "id",
-                    request.Page ?? 1);
+                    request.Page ?? 1,
+                    pageSize);
 
                 var list = results.AsQueryable()
                     .ProjectTo<SearchResult>(_mapper.ConfigurationProvider)
                     .ToList();
 
                 var totalCount = await _dbQueryData.GetSearchResultsTotalsAsync(request.SearchRequestBody);
+                var pageCount = (totalCount + pageSize - 1) / pageSize;
 
                 return new Response
                 {
                     TotalCount = totalCount,
                     Page = request.Page,
                     Results = list,
-                    PageCount = results.Count
+                    PageCount = pageCount,
                 };
             }
         }

--- a/src/API/LeadershipProfileAPI/Features/Search/MappingProfile.cs
+++ b/src/API/LeadershipProfileAPI/Features/Search/MappingProfile.cs
@@ -7,8 +7,6 @@ namespace LeadershipProfileAPI.Features.Search
         public MappingProfile()
         {
             CreateMap<StaffSearch, List.SearchResult>()
-                .ForMember(d => d.FullName, o => o.MapFrom(x => GetFullName(x.FirstName, x.MiddleName, x.LastSurname)));
-            CreateMap<StaffSearchGroup, List.SearchResult>()
                 .ForMember(d => d.FullName, o => o.MapFrom(x => GetFullName(x.FirstName, null, x.LastSurname)));
         }
 


### PR DESCRIPTION
Fix up queries and data model after updating to TPDM 1.0 and seeding explicit test data (#86)

- add many unit tests for search filters
  - in particular, validating and resolving multiple results for the same person
  - adds (tested) utility to paginate over all results
- fix data mapping issues
  - fixes pagination calculation
  - excludes historical staff assignments
 
This **does not** include updates for Performance Data, which will be included in a subsequent PR.