### PR TITLE
Hide Card View Links

### DIFF
--- a/src/Web/src/App.css
+++ b/src/Web/src/App.css
@@ -85,6 +85,7 @@
   position: relative;
   top: 3.5rem;
   cursor: pointer;
+  display: none;
 }
 
 .view-style-buttons > a {


### PR DESCRIPTION
Hide the option to toggle to the "card" view in the Directory (as opposed to the table) given the incorrect styling and incomplete functionality. This is the "soft" removal so the cards can be fixed up and enhanced in the future.