### PR TITLE
Trigger search by name feature with 2 characters

### DIFF
--- a/src/Web/src/components/DirectoryComponents/DirectoryFilters.js
+++ b/src/Web/src/components/DirectoryComponents/DirectoryFilters.js
@@ -74,7 +74,7 @@ const CreateDirectoryFilters = (props) => {
 
         function NameSearch_OnChange(value){
             setNameSearch(value);
-            if(value.length >= 3 || value.length === 0){
+            if(value.length >= 2 || value.length === 0){
                 sendFilter(FilterActions.setNameFilter, value);
             }
         }


### PR DESCRIPTION
The number of characters required to trigger the search by name feature was changed from 3 to 2 required characters.