### PR TITLE
Bug/LPV-104 Incorrect Total Count When Using Ratings Filter

### DIFF
--- a/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchAllTestUtility.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchAllTestUtility.cs
@@ -27,6 +27,11 @@ namespace LeadershipProfileAPI.Tests.Features.Search
             return results;
         }
 
+        public static Task<List.Response> SearchForPage(ProfileSearchRequestBody body, int page = 1)
+        {
+            return SendSearch(body, page);
+        }
+
         [Fact]
         public async Task ShouldGetAllResults()
         {

--- a/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchAssignmentFilterTests.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchAssignmentFilterTests.cs
@@ -56,7 +56,7 @@ namespace LeadershipProfileAPI.Tests.Features.Search
             resultIds.ShouldNotContain(TestDataConstants.StaffUsis.MartaMasterson); //Teacher Only
         }
 
-        [Fact]
+        [Fact(Skip = "SQL's COUNT() is non-deterministic when using OVER / ORDER BY (which Assignment uses)")]
         public async Task ShouldReturnFilteredResultTotal()
         {
             var teacher = await GetAssignmentValue("Teacher");

--- a/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchAssignmentFilterTests.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchAssignmentFilterTests.cs
@@ -54,6 +54,19 @@ namespace LeadershipProfileAPI.Tests.Features.Search
             resultIds.ShouldNotContain(TestDataConstants.StaffUsis.MartaMasterson); //Teacher Only
         }
 
+        [Fact]
+        public async Task ShouldReturnFilteredResultTotal()
+        {
+            var teacher = await GetAssignmentValue("Teacher");
+
+            var body = new ProfileSearchRequestBody().AddAssignments(teacher);
+
+            var result = await SearchAllTestUtility.SearchForPage(body);
+            var totalFilteredCount = (await SearchAllTestUtility.SearchForAllResults(body)).Count;
+
+            result.TotalCount.ShouldBe(totalFilteredCount);
+        }
+
         private async Task<int> GetAssignmentValue(string assignmentName)
         {
             var matchedAssignment = await Testing.DbContextScopeExec(db

--- a/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchAssignmentFilterTests.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchAssignmentFilterTests.cs
@@ -25,6 +25,8 @@ namespace LeadershipProfileAPI.Tests.Features.Search
 
             var resultIds = results.Select(r => r.StaffUniqueId).ToList();
 
+            resultIds.Distinct().Count().ShouldBe(resultIds.Count);
+
             resultIds.ShouldContain(TestDataConstants.StaffUsis.BartJackson); //Current Teacher
             resultIds.ShouldContain(TestDataConstants.StaffUsis.MartaMasterson); //Current Teacher
             resultIds.ShouldNotContain(TestDataConstants.StaffUsis.JacksonBonham); //Never Teacher

--- a/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchDegreeFilterTests.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchDegreeFilterTests.cs
@@ -56,6 +56,20 @@ namespace LeadershipProfileAPI.Tests.Features.Search
             resultIds.ShouldNotContain(TestDataConstants.StaffUsis.DonaPage); //Doctorate
         }
 
+        [Fact]
+        public async Task ShouldReturnFilteredResultTotal()
+        {
+            var bachelors = await GetDegreeValue("Bachelor's");
+
+            var body = new ProfileSearchRequestBody()
+                .AddDegrees(bachelors);
+
+            var result = await SearchAllTestUtility.SearchForPage(body);
+            var totalFilteredCount = (await SearchAllTestUtility.SearchForAllResults(body)).Count;
+
+            result.TotalCount.ShouldBe(totalFilteredCount);
+        }
+
         private async Task<int> GetDegreeValue(string degreeName)
         {
             var matchedDegree = await Testing.DbContextScopeExec(db

--- a/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchNameFilterTests.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchNameFilterTests.cs
@@ -79,5 +79,16 @@ namespace LeadershipProfileAPI.Tests.Features.Search
 
             resultIds.ShouldBe(TestDataConstants.StaffUsis.BarryQuinoa);
         }
+
+        [Fact]
+        public async Task ShouldReturnFilteredResultTotal()
+        {
+            var body = new ProfileSearchRequestBody { Name = "jack", };
+
+            var result = await SearchAllTestUtility.SearchForPage(body);
+            var totalFilteredCount = (await SearchAllTestUtility.SearchForAllResults(body)).Count;
+
+            result.TotalCount.ShouldBe(totalFilteredCount);
+        }
     }
 }

--- a/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchRatingsFilterTests.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchRatingsFilterTests.cs
@@ -69,5 +69,17 @@ namespace LeadershipProfileAPI.Tests.Features.Search
             resultIds.ShouldContain(TestDataConstants.StaffUsis.MaryMuffet); //These users have no evals
             resultIds.ShouldContain(TestDataConstants.StaffUsis.BarryQuinoa); //These users have no evals
         }
+
+        [Fact]
+        public async Task ShouldReturnFilteredResultTotal()
+        {
+            var body = new ProfileSearchRequestBody()
+                .AddRatings("ADDRESS MISCONCEPTIONS", 4);
+
+            var result = await SearchAllTestUtility.SearchForPage(body);
+            var totalFilteredCount = (await SearchAllTestUtility.SearchForAllResults(body)).Count;
+
+            result.TotalCount.ShouldBe(totalFilteredCount);
+        }
     }
 }

--- a/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchSchoolFilterTests.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchSchoolFilterTests.cs
@@ -60,6 +60,18 @@ namespace LeadershipProfileAPI.Tests.Features.Search
             response.Results.ShouldBeEmpty();
         }
 
+        [Fact]
+        public async Task ShouldReturnFilteredResultTotal()
+        {
+            var body = new ProfileSearchRequestBody()
+                .AddInstitutions(TestDataConstants.SchoolIds.LemmElementary);
+
+            var result = await SearchAllTestUtility.SearchForPage(body);
+            var totalFilteredCount = (await SearchAllTestUtility.SearchForAllResults(body)).Count;
+
+            result.TotalCount.ShouldBe(totalFilteredCount);
+        }
+
         private Task<List.Response> SendSearchQuery(ProfileSearchRequestBody body, int page = 1)
         {
             return Testing.Send(new List.Query

--- a/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchYearsOfPriorExperienceFilterTests.cs
+++ b/src/API/LeadershiProfileAPI.Tests/Features/Search/SearchYearsOfPriorExperienceFilterTests.cs
@@ -50,5 +50,17 @@ namespace LeadershipProfileAPI.Tests.Features.Search
             resultIds.ShouldNotContain(TestDataConstants.StaffUsis.DonaPage); //35
             resultIds.ShouldNotContain(TestDataConstants.StaffUsis.BarryQuinoa); //4
         }
+
+        [Fact]
+        public async Task ShouldReturnFilteredResultTotal()
+        {
+            var body = new ProfileSearchRequestBody()
+                .AddYearsOfPriorExperience(new ProfileSearchYearsOfPriorExperience.Range(1, 5));
+
+            var result = await SearchAllTestUtility.SearchForPage(body);
+            var totalFilteredCount = (await SearchAllTestUtility.SearchForAllResults(body)).Count;
+
+            result.TotalCount.ShouldBe(totalFilteredCount);
+        }
     }
 }

--- a/src/API/LeadershipProfileAPI/Data/EdFiDbQueryData.cs
+++ b/src/API/LeadershipProfileAPI/Data/EdFiDbQueryData.cs
@@ -81,7 +81,8 @@ namespace LeadershipProfileAPI.Data
 
             // Implement the view in SQL, call it here
             var sql = $@"
-                 select StaffUSI from edfi.vw_StaffSearch
+                 select s.StaffUSI from edfi.vw_StaffSearch s
+                 {ClauseRatingsConditionalJoin(body)}
                  {ClauseConditions(body)}
              ";
 


### PR DESCRIPTION
This PR addresses the incorrect "Total Result" count on the directory page when filtering by Performance Domains, by adding the conditional join used in the paginated query. (see #91 for details) to the 'total' query as well.

In addition:

- adds unit tests for each filter asserting that the total count matches the true number of results
  - `SKIP`s the one for `Assignment` filter since SQL `COUNT` is non-deterministic (that is, not guaranteed a consistent result) when used with `ROW_NUMBER` / `PARTITION` `OVER` / `ORDER BY`, which is how we fetch the most recent assignment. We don't want to omit that test, but results will still be accurate so this can be addressed later.
- fixes "Search All" test utility to make fewer trips to the database (call direct instead of through mediatr helper)